### PR TITLE
Add docker build action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: ci
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+      
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ghcr.io/evercam/ex_nvr
+      
+    - name: Login to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64/v8
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.14.3-erlang-25.2.3-alpine-3.16.3 AS build
+FROM hexpm/elixir:1.14.3-erlang-24.3.1-alpine-3.18.0 AS build
 
 # install build dependencies
 RUN \
@@ -42,7 +42,7 @@ RUN cd apps/ex_nvr_web && mix assets.deploy
 RUN mix do compile, release
 
 # prepare release image
-FROM alpine:3.16.3 AS app
+FROM alpine:3.18.0 AS app
 
 # install runtime dependencies
 RUN \


### PR DESCRIPTION
Create a `CI` github action. The action will be triggered once we push a tag, a docker container with two tags `latest` and `tag {version}` will be created.

Note that due to a bug in `QEMU` with `erlang OTP 25`, multi-arch docker building fails, this is why we fall back to `OTP 24` for the time being.