### PR TITLE
Fix onvif discovery

### DIFF
--- a/apps/ex_nvr/lib/ex_nvr/onvif.ex
+++ b/apps/ex_nvr/lib/ex_nvr/onvif.ex
@@ -3,6 +3,8 @@ defmodule ExNVR.Onvif do
   Onvif client
   """
 
+  import ExNVR.Onvif.Utils, only: [delete_namespaces: 1]
+
   alias ExNVR.Onvif.{Discovery, Http}
 
   @default_timeout 3_000
@@ -83,27 +85,4 @@ defmodule ExNVR.Onvif do
 
   defp handle_response({:ok, response}, _parse), do: {:error, response}
   defp handle_response(response, _parse), do: response
-
-  defp delete_namespaces(response) when is_map(response) do
-    Enum.reduce(response, %{}, fn {key, value}, acc ->
-      Map.put(acc, delete_namespace(key), delete_namespaces(value))
-    end)
-  end
-
-  defp delete_namespaces(response) when is_list(response) do
-    Enum.map(response, &delete_namespaces/1)
-  end
-
-  defp delete_namespaces({key, value}) do
-    {delete_namespace(key), delete_namespaces(value)}
-  end
-
-  defp delete_namespaces(response), do: response
-
-  defp delete_namespace(key) do
-    to_string(key)
-    |> String.split(":")
-    |> List.last()
-    |> String.to_atom()
-  end
 end

--- a/apps/ex_nvr/lib/ex_nvr/onvif/discovery.ex
+++ b/apps/ex_nvr/lib/ex_nvr/onvif/discovery.ex
@@ -1,6 +1,7 @@
 defmodule ExNVR.Onvif.Discovery do
   @moduledoc false
 
+  import ExNVR.Onvif.Utils, only: [delete_namespaces: 1]
   import Mockery.Macro
 
   @multicast_addr {239, 255, 255, 250}
@@ -34,6 +35,7 @@ defmodule ExNVR.Onvif.Discovery do
       |> Enum.map(&String.replace(&1, ["\r\n", "\r", "\n"], ""))
       |> Enum.map(&%Soap.Response{body: &1, status_code: 200})
       |> Enum.map(&Soap.Response.parse/1)
+      |> Enum.map(&delete_namespaces/1)
       |> Enum.map(&format_response/1)
       |> then(&{:ok, &1})
     end
@@ -51,12 +53,12 @@ defmodule ExNVR.Onvif.Discovery do
   end
 
   defp format_response(response) do
-    probe_match = get_in(response, [:"d:ProbeMatches", :"d:ProbeMatch"])
-    scopes = probe_match[:"d:Scopes"] |> String.split()
+    probe_match = get_in(response, [:ProbeMatches, :ProbeMatch])
+    scopes = probe_match[:Scopes] |> String.split()
 
     %{
-      types: probe_match[:"d:Types"] |> String.split(),
-      addresses: probe_match[:"d:XAddrs"] |> String.split()
+      types: probe_match[:Types] |> String.split(),
+      addresses: probe_match[:XAddrs] |> String.split()
     }
     |> Map.merge(parse_scopes(scopes))
   end

--- a/apps/ex_nvr/lib/ex_nvr/onvif/utils.ex
+++ b/apps/ex_nvr/lib/ex_nvr/onvif/utils.ex
@@ -1,0 +1,30 @@
+defmodule ExNVR.Onvif.Utils do
+  @moduledoc false
+
+  @doc """
+  Delete namespaces from the converted XML
+  """
+  @spec delete_namespaces(map()) :: map()
+  def delete_namespaces(response) when is_map(response) do
+    Enum.reduce(response, %{}, fn {key, value}, acc ->
+      Map.put(acc, delete_namespace(key), delete_namespaces(value))
+    end)
+  end
+
+  def delete_namespaces(response) when is_list(response) do
+    Enum.map(response, &delete_namespaces/1)
+  end
+
+  def delete_namespaces({key, value}) do
+    {delete_namespace(key), delete_namespaces(value)}
+  end
+
+  def delete_namespaces(response), do: response
+
+  defp delete_namespace(key) do
+    to_string(key)
+    |> String.split(":")
+    |> List.last()
+    |> String.to_atom()
+  end
+end

--- a/apps/ex_nvr_web/lib/ex_nvr_web/live/onvif_discovery_live.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/live/onvif_discovery_live.ex
@@ -268,7 +268,6 @@ defmodule ExNVRWeb.OnvifDiscoveryLive do
   defp display_key(key) do
     to_string(key)
     |> String.split("_")
-    |> Enum.map(&Macro.camelize/1)
-    |> Enum.join(" ")
+    |> Enum.map_join(" ", &Macro.camelize/1)
   end
 end

--- a/apps/ex_nvr_web/lib/ex_nvr_web/live/onvif_discovery_live.html.heex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/live/onvif_discovery_live.html.heex
@@ -20,11 +20,11 @@
       </.simple_form>
     </.card>
     <!-- Found devices -->
-    <.card class="w-full md:w-3/5 p-4 overflow-scroll">
+    <.card class="w-full md:w-3/5 p-4">
       <h2 class="text-2xl font-bold mb-4 dark:text-white">Found Devices</h2>
       <p :if={@discovered_devices == []} class="text-l dark:text-white">No devices found</p>
 
-      <ul class="bg-white dark:bg-gray-800 h-200 dark:text-white overflow-scroll">
+      <ul class="bg-white dark:bg-gray-800 h-200 dark:text-white">
         <li
           :for={new_device <- @discovered_devices}
           id={new_device.name}


### PR DESCRIPTION
Delete the namespaces in the XML response before parsing as each device can use different names for the namespaces.