### PR TITLE
Avoid silent failures by creating directories in pipeline

### DIFF
--- a/apps/ex_nvr/lib/ex_nvr.ex
+++ b/apps/ex_nvr/lib/ex_nvr.ex
@@ -24,9 +24,9 @@ defmodule ExNVR do
 
   # create recording & HLS directories
   defp create_directories() do
-    File.mkdir_p!(recording_dir())
-    File.mkdir_p!(hls_dir())
-    File.mkdir_p!(unix_socket_dir())
+    File.mkdir_p(recording_dir())
+    File.mkdir_p(hls_dir())
+    File.mkdir_p(unix_socket_dir())
   end
 
   defp create_admin_user() do

--- a/apps/ex_nvr/lib/ex_nvr/bif_generator_server.ex
+++ b/apps/ex_nvr/lib/ex_nvr/bif_generator_server.ex
@@ -24,6 +24,10 @@ defmodule ExNVR.BifGeneratorServer do
 
   @impl true
   def handle_info(:tick, %{device: device} = state) do
+    unless File.exists?(Utils.bif_dir(device.id)) do
+      File.mkdir!(Utils.bif_dir(device.id))
+    end
+
     list_hours(device)
     |> Enum.each(fn start_date ->
       Logger.info("BifGenerator: generate BIF file #{inspect(start_date)}")

--- a/apps/ex_nvr/lib/ex_nvr/device_supervisor.ex
+++ b/apps/ex_nvr/lib/ex_nvr/device_supervisor.ex
@@ -3,8 +3,6 @@ defmodule ExNVR.DeviceSupervisor do
 
   use Supervisor
 
-  import ExNVR.Utils
-
   alias ExNVR.Model.Device
   alias ExNVR.Pipelines.Main
 
@@ -25,10 +23,6 @@ defmodule ExNVR.DeviceSupervisor do
 
   @impl true
   def init(device) do
-    File.mkdir_p!(recording_dir(device.id))
-    File.mkdir_p!(hls_dir(device.id))
-    File.mkdir_p!(bif_dir(device.id))
-
     params = [device: device]
 
     children = [
@@ -42,7 +36,7 @@ defmodule ExNVR.DeviceSupervisor do
         _other -> children
       end
 
-    Supervisor.init(children, strategy: :rest_for_one, max_restarts: 1_000)
+    Supervisor.init(children, strategy: :rest_for_one, max_restarts: 10_000)
   end
 
   @spec stop(Device.t()) :: :ok

--- a/apps/ex_nvr/lib/ex_nvr/pipelines/main.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipelines/main.ex
@@ -173,11 +173,23 @@ defmodule ExNVR.Pipelines.Main do
 
   @impl true
   def handle_setup(_ctx, state) do
+    do_create_directories(state.device)
+
     # Set device state and make last active run inactive
     # may happens on application crash
     device_state = if state.device.type == :file, do: :recording, else: :failed
     Recordings.deactivate_runs(state.device)
     {[], maybe_update_device_and_report(state, device_state)}
+  end
+
+  defp do_create_directories(device) do
+    unless File.exists?(Utils.recording_dir(device.id)) do
+      File.mkdir!(Utils.recording_dir(device.id))
+    end
+
+    unless File.exists?(Utils.hls_dir(device.id)) do
+      File.mkdir!(Utils.hls_dir(device.id))
+    end
   end
 
   @impl true

--- a/apps/ex_nvr/mix.exs
+++ b/apps/ex_nvr/mix.exs
@@ -4,7 +4,7 @@ defmodule ExNVR.MixProject do
   def project do
     [
       app: :ex_nvr,
-      version: "0.5.0",
+      version: "0.5.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ex_nvr_web/mix.exs
+++ b/apps/ex_nvr_web/mix.exs
@@ -4,7 +4,7 @@ defmodule ExNVRWeb.MixProject do
   def project do
     [
       app: :ex_nvr_web,
-      version: "0.4.0",
+      version: "0.5.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ex_nvr_web/priv/static/openapi.yaml
+++ b/apps/ex_nvr_web/priv/static/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: ExNVR API
   description: Manage ExNVR via API endpoints
-  version: 0.5.0
+  version: 0.5.1
 servers:
   - url: '{protocol}://{host}:{port}'
     variables:

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExNVR.Umbrella.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.5.1"
 
   def project do
     [


### PR DESCRIPTION
Fix a bug where the pipeline doesn't start if the directories aren't created. Sometimes the hard drive disconnect for a brief moment which makes the creation of folders fails. Moving the creation of folders to the pipeline so that the supervisor will restart the pipeline in case of failure.