### PR TITLE
Add device settings

### DIFF
--- a/apps/ex_nvr/lib/ex_nvr.ex
+++ b/apps/ex_nvr/lib/ex_nvr.ex
@@ -24,7 +24,6 @@ defmodule ExNVR do
 
   # create recording & HLS directories
   defp create_directories() do
-    File.mkdir_p(recording_dir())
     File.mkdir_p(hls_dir())
     File.mkdir_p(unix_socket_dir())
   end

--- a/apps/ex_nvr/lib/ex_nvr/bif_generator_server.ex
+++ b/apps/ex_nvr/lib/ex_nvr/bif_generator_server.ex
@@ -24,20 +24,22 @@ defmodule ExNVR.BifGeneratorServer do
 
   @impl true
   def handle_info(:tick, %{device: device} = state) do
-    list_hours(device)
-    |> Enum.each(fn start_date ->
-      Logger.info("BifGenerator: generate BIF file #{inspect(start_date)}")
+    if device.settings.generate_bif do
+      list_hours(device)
+      |> Enum.each(fn start_date ->
+        Logger.info("BifGenerator: generate BIF file #{inspect(start_date)}")
 
-      {:ok, _sup_pid, pip_pid} =
-        BifGenerator.start(
-          device: device,
-          start_date: start_date,
-          end_date: DateTime.add(start_date, 1, :hour),
-          location: bif_location(device, start_date)
-        )
+        {:ok, _sup_pid, pip_pid} =
+          BifGenerator.start(
+            device: device,
+            start_date: start_date,
+            end_date: DateTime.add(start_date, 1, :hour),
+            location: bif_location(device, start_date)
+          )
 
-      wait_for_pipeline(pip_pid)
-    end)
+        wait_for_pipeline(pip_pid)
+      end)
+    end
 
     Process.send_after(self(), :tick, :timer.minutes(5))
     {:noreply, state}

--- a/apps/ex_nvr/lib/ex_nvr/bif_generator_server.ex
+++ b/apps/ex_nvr/lib/ex_nvr/bif_generator_server.ex
@@ -7,8 +7,8 @@ defmodule ExNVR.BifGeneratorServer do
 
   require Logger
 
+  alias ExNVR.Model.Device
   alias ExNVR.Pipelines.BifGenerator
-  alias ExNVR.Utils
 
   def start_link(options) do
     GenServer.start_link(__MODULE__, options)
@@ -24,10 +24,6 @@ defmodule ExNVR.BifGeneratorServer do
 
   @impl true
   def handle_info(:tick, %{device: device} = state) do
-    unless File.exists?(Utils.bif_dir(device)) do
-      File.mkdir!(Utils.bif_dir(device))
-    end
-
     list_hours(device)
     |> Enum.each(fn start_date ->
       Logger.info("BifGenerator: generate BIF file #{inspect(start_date)}")
@@ -64,7 +60,7 @@ defmodule ExNVR.BifGeneratorServer do
   end
 
   defp from_stored_files(device) do
-    Utils.bif_dir(device)
+    Device.bif_dir(device)
     |> Path.join("*.bif")
     |> Path.wildcard()
     |> Enum.sort(:desc)
@@ -96,7 +92,7 @@ defmodule ExNVR.BifGeneratorServer do
 
   defp bif_location(device, start_date) do
     formatted_date = Calendar.strftime(start_date, "%Y%m%d%H.bif")
-    Path.join(Utils.bif_dir(device), formatted_date)
+    Path.join(Device.bif_dir(device), formatted_date)
   end
 
   defp wait_for_pipeline(pip_pid) do

--- a/apps/ex_nvr/lib/ex_nvr/bif_generator_server.ex
+++ b/apps/ex_nvr/lib/ex_nvr/bif_generator_server.ex
@@ -24,8 +24,8 @@ defmodule ExNVR.BifGeneratorServer do
 
   @impl true
   def handle_info(:tick, %{device: device} = state) do
-    unless File.exists?(Utils.bif_dir(device.id)) do
-      File.mkdir!(Utils.bif_dir(device.id))
+    unless File.exists?(Utils.bif_dir(device)) do
+      File.mkdir!(Utils.bif_dir(device))
     end
 
     list_hours(device)
@@ -34,7 +34,7 @@ defmodule ExNVR.BifGeneratorServer do
 
       {:ok, _sup_pid, pip_pid} =
         BifGenerator.start(
-          device_id: device.id,
+          device: device,
           start_date: start_date,
           end_date: DateTime.add(start_date, 1, :hour),
           location: bif_location(device, start_date)
@@ -64,7 +64,7 @@ defmodule ExNVR.BifGeneratorServer do
   end
 
   defp from_stored_files(device) do
-    Utils.bif_dir(device.id)
+    Utils.bif_dir(device)
     |> Path.join("*.bif")
     |> Path.wildcard()
     |> Enum.sort(:desc)
@@ -96,7 +96,7 @@ defmodule ExNVR.BifGeneratorServer do
 
   defp bif_location(device, start_date) do
     formatted_date = Calendar.strftime(start_date, "%Y%m%d%H.bif")
-    Path.join(Utils.bif_dir(device.id), formatted_date)
+    Path.join(Utils.bif_dir(device), formatted_date)
   end
 
   defp wait_for_pipeline(pip_pid) do

--- a/apps/ex_nvr/lib/ex_nvr/devices.ex
+++ b/apps/ex_nvr/lib/ex_nvr/devices.ex
@@ -10,9 +10,10 @@ defmodule ExNVR.Devices do
 
   @spec create(map()) :: {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
   def create(params) do
-    %Device{}
-    |> Device.create_changeset(params)
-    |> Repo.insert()
+    with {:ok, device} = result <- Repo.insert(Device.create_changeset(params)) do
+      create_device_directories(device)
+      result
+    end
   end
 
   @spec update(Device.t(), map()) :: {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
@@ -48,5 +49,12 @@ defmodule ExNVR.Devices do
   @spec change_device_update(Device.t(), map()) :: Ecto.Changeset.t()
   def change_device_update(%Device{} = device, attrs \\ %{}) do
     Device.update_changeset(device, attrs)
+  end
+
+  defp create_device_directories(device) do
+    File.mkdir_p!(Device.base_dir(device))
+    File.mkdir_p!(Device.recording_dir(device))
+    File.mkdir_p!(Device.recording_dir(device, :low))
+    File.mkdir_p!(Device.bif_dir(device))
   end
 end

--- a/apps/ex_nvr/lib/ex_nvr/elements/recording_bin.ex
+++ b/apps/ex_nvr/lib/ex_nvr/elements/recording_bin.ex
@@ -20,7 +20,7 @@ defmodule ExNVR.Elements.RecordingBin do
 
   def_options device: [
                 spec: ExNVR.Model.Device.t(),
-                description: "The device id from where to read the recordings"
+                description: "The device from where to read the recordings"
               ],
               start_date: [
                 spec: DateTime.t(),

--- a/apps/ex_nvr/lib/ex_nvr/elements/recording_bin.ex
+++ b/apps/ex_nvr/lib/ex_nvr/elements/recording_bin.ex
@@ -158,19 +158,15 @@ defmodule ExNVR.Elements.RecordingBin do
     id = recording.id
 
     spec = [
-      child({:source, id}, %File.Source{location: recording_path(state.device, recording)})
+      child({:source, id}, %File.Source{
+        location: Recordings.recording_path(state.device, recording)
+      })
       |> child({:demuxer, id}, MP4.Demuxer.ISOM)
     ]
 
     state = update_recording_duration(state)
 
     {spec, %{state | recordings: rest, current_recording: recording}}
-  end
-
-  defp recording_path(device, recording) do
-    device
-    |> ExNVR.Utils.recording_dir()
-    |> Path.join(recording.filename)
   end
 
   defp update_recording_duration(%{current_recording: nil} = state), do: state

--- a/apps/ex_nvr/lib/ex_nvr/elements/recording_bin.ex
+++ b/apps/ex_nvr/lib/ex_nvr/elements/recording_bin.ex
@@ -18,8 +18,8 @@ defmodule ExNVR.Elements.RecordingBin do
   alias ExNVR.Elements.Recording.Timestamper
   alias Membrane.{File, H264, MP4}
 
-  def_options device_id: [
-                spec: binary(),
+  def_options device: [
+                spec: ExNVR.Model.Device.t(),
                 description: "The device id from where to read the recordings"
               ],
               start_date: [
@@ -68,7 +68,7 @@ defmodule ExNVR.Elements.RecordingBin do
     Membrane.Logger.debug("Initialize recording bin: #{inspect(options)}")
 
     recordings =
-      Recordings.get_recordings_between(options.device_id, options.start_date, options.end_date)
+      Recordings.get_recordings_between(options.device.id, options.start_date, options.end_date)
 
     state =
       Map.from_struct(options)
@@ -125,7 +125,7 @@ defmodule ExNVR.Elements.RecordingBin do
   def handle_element_end_of_stream({:timestamper, id}, pad, ctx, %{recordings: []} = state) do
     recordings =
       Recordings.get_recordings_between(
-        state.device_id,
+        state.device.id,
         state.current_recording.end_date,
         state.end_date
       )
@@ -158,7 +158,7 @@ defmodule ExNVR.Elements.RecordingBin do
     id = recording.id
 
     spec = [
-      child({:source, id}, %File.Source{location: recording_path(state.device_id, recording)})
+      child({:source, id}, %File.Source{location: recording_path(state.device, recording)})
       |> child({:demuxer, id}, MP4.Demuxer.ISOM)
     ]
 
@@ -167,8 +167,8 @@ defmodule ExNVR.Elements.RecordingBin do
     {spec, %{state | recordings: rest, current_recording: recording}}
   end
 
-  defp recording_path(device_id, recording) do
-    device_id
+  defp recording_path(device, recording) do
+    device
     |> ExNVR.Utils.recording_dir()
     |> Path.join(recording.filename)
   end

--- a/apps/ex_nvr/lib/ex_nvr/model/device.ex
+++ b/apps/ex_nvr/lib/ex_nvr/model/device.ex
@@ -138,6 +138,13 @@ defmodule ExNVR.Model.Device do
         end
       end)
     end
+
+    @spec update_changeset(t(), map()) :: Ecto.Changeset.t()
+    def update_changeset(struct, params) do
+      struct
+      |> cast(params, [:generate_bif])
+      |> validate_required([:storage_address])
+    end
   end
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -201,6 +208,7 @@ defmodule ExNVR.Model.Device do
     device
     |> Changeset.cast(params, [:name, :type, :timezone, :state])
     |> Changeset.cast_embed(:credentials)
+    |> Changeset.cast_embed(:settings, required: true)
     |> common_config()
   end
 
@@ -208,6 +216,7 @@ defmodule ExNVR.Model.Device do
     device
     |> Changeset.cast(params, [:name, :timezone, :state])
     |> Changeset.cast_embed(:credentials)
+    |> Changeset.cast_embed(:settings, required: true, with: &Settings.update_changeset/2)
     |> common_config()
   end
 
@@ -215,7 +224,6 @@ defmodule ExNVR.Model.Device do
     changeset
     |> Changeset.validate_required([:name, :type])
     |> Changeset.validate_inclusion(:timezone, Tzdata.zone_list())
-    |> Changeset.cast_embed(:settings, required: true)
     |> validate_config()
   end
 

--- a/apps/ex_nvr/lib/ex_nvr/model/recording.ex
+++ b/apps/ex_nvr/lib/ex_nvr/model/recording.ex
@@ -54,6 +54,12 @@ defmodule ExNVR.Model.Recording do
     where(query, [r], r.device_id == ^device_id)
   end
 
+  def with_name(query \\ __MODULE__, name) do
+    where(query, [r], r.filename == ^name)
+  end
+
+  def preload_device(query \\ __MODULE__), do: preload(query, [:device])
+
   def list_with_devices() do
     from(r in __MODULE__,
       join: d in assoc(r, :device),

--- a/apps/ex_nvr/lib/ex_nvr/model/recording.ex
+++ b/apps/ex_nvr/lib/ex_nvr/model/recording.ex
@@ -54,11 +54,9 @@ defmodule ExNVR.Model.Recording do
     where(query, [r], r.device_id == ^device_id)
   end
 
-  def with_name(query \\ __MODULE__, name) do
-    where(query, [r], r.filename == ^name)
+  def get_query(query \\ __MODULE__, device_id, name) do
+    from(r in query, where: r.device_id == ^device_id and r.filename == ^name, preload: [:device])
   end
-
-  def preload_device(query \\ __MODULE__), do: preload(query, [:device])
 
   def list_with_devices() do
     from(r in __MODULE__,

--- a/apps/ex_nvr/lib/ex_nvr/model/recording/download.ex
+++ b/apps/ex_nvr/lib/ex_nvr/model/recording/download.ex
@@ -14,9 +14,9 @@ defmodule ExNVR.Model.Recording.Download do
   defstruct path: nil, start_date: nil, end_date: nil
 
   @spec new(Recording.t(), Path.t()) :: t()
-  def new(%Recording{} = recording, recordings_dir) do
+  def new(%Recording{} = recording, recording_path) do
     %__MODULE__{
-      path: Path.join(recordings_dir, recording.filename),
+      path: recording_path,
       start_date: DateTime.to_unix(recording.start_date, :millisecond),
       end_date: DateTime.to_unix(recording.end_date, :millisecond)
     }

--- a/apps/ex_nvr/lib/ex_nvr/pipelines/bif_generator.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipelines/bif_generator.ex
@@ -13,7 +13,7 @@ defmodule ExNVR.Pipelines.BifGenerator do
   def handle_init(_ctx, options) do
     spec = [
       child(:source, %ExNVR.Elements.RecordingBin{
-        device_id: options[:device_id],
+        device: options[:device],
         start_date: options[:start_date],
         end_date: options[:end_date],
         strategy: :exact

--- a/apps/ex_nvr/lib/ex_nvr/pipelines/hls_playback.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipelines/hls_playback.ex
@@ -35,12 +35,12 @@ defmodule ExNVR.Pipelines.HlsPlayback do
 
   @impl true
   def handle_init(_ctx, options) do
-    Logger.metadata(device_id: options[:device_id])
+    Logger.metadata(device_id: options[:device].id)
     Membrane.Logger.info("Start playback pipeline with options: #{inspect(options)}")
 
     spec = [
       child(:source, %Elements.RecordingBin{
-        device_id: options[:device_id],
+        device: options[:device],
         start_date: options[:start_date]
       })
       |> via_out(:video)

--- a/apps/ex_nvr/lib/ex_nvr/pipelines/main.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipelines/main.ex
@@ -173,23 +173,11 @@ defmodule ExNVR.Pipelines.Main do
 
   @impl true
   def handle_setup(_ctx, state) do
-    do_create_directories(state.device)
-
     # Set device state and make last active run inactive
     # may happens on application crash
     device_state = if state.device.type == :file, do: :recording, else: :failed
     Recordings.deactivate_runs(state.device)
     {[], maybe_update_device_and_report(state, device_state)}
-  end
-
-  defp do_create_directories(device) do
-    unless File.exists?(Utils.recording_dir(device)) do
-      File.mkdir!(Utils.recording_dir(device))
-    end
-
-    unless File.exists?(Utils.hls_dir(device.id)) do
-      File.mkdir!(Utils.hls_dir(device.id))
-    end
   end
 
   @impl true

--- a/apps/ex_nvr/lib/ex_nvr/pipelines/main.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipelines/main.ex
@@ -183,8 +183,8 @@ defmodule ExNVR.Pipelines.Main do
   end
 
   defp do_create_directories(device) do
-    unless File.exists?(Utils.recording_dir(device.id)) do
-      File.mkdir!(Utils.recording_dir(device.id))
+    unless File.exists?(Utils.recording_dir(device)) do
+      File.mkdir!(Utils.recording_dir(device))
     end
 
     unless File.exists?(Utils.hls_dir(device.id)) do
@@ -362,8 +362,7 @@ defmodule ExNVR.Pipelines.Main do
       |> child(:video_tee, Membrane.Tee.Master)
       |> via_out(:master)
       |> child({:storage_bin, :main_stream}, %Output.Storage{
-        device_id: state.device.id,
-        directory: Utils.recording_dir(state.device.id),
+        device: state.device,
         target_segment_duration: state.segment_duration,
         correct_timestamp: true
       }),

--- a/apps/ex_nvr/lib/ex_nvr/pipelines/snapshot.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipelines/snapshot.ex
@@ -16,14 +16,14 @@ defmodule ExNVR.Pipelines.Snapshot do
 
   @impl true
   def handle_init(_ctx, options) do
-    Logger.metadata(device_id: options[:device_id])
+    Logger.metadata(device_id: options[:device].id)
     Membrane.Logger.info("Start snapshot pipeline with options: #{inspect(options)}")
 
     rank = if options[:method] == :precise, do: :last, else: :first
 
     spec = [
       child(:source, %RecordingBin{
-        device_id: options[:device_id],
+        device: options[:device],
         start_date: options[:date],
         end_date: options[:date],
         strategy: :keyframe_before

--- a/apps/ex_nvr/lib/ex_nvr/pipelines/video_assembler.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipelines/video_assembler.ex
@@ -14,7 +14,7 @@ defmodule ExNVR.Pipelines.VideoAssembler do
 
   @impl true
   def handle_init(_ctx, options) do
-    Logger.metadata(device_id: options[:device_id])
+    Logger.metadata(device_id: options[:device].id)
     Membrane.Logger.info("Initialize VideoAssembler pipeline with: #{inspect(options)}")
 
     spec = [
@@ -28,7 +28,7 @@ defmodule ExNVR.Pipelines.VideoAssembler do
       })
     ]
 
-    {[spec: spec], %{device_id: options[:device_id]}}
+    {[spec: spec], %{device: options[:device]}}
   end
 
   @impl true

--- a/apps/ex_nvr/lib/ex_nvr/recordings.ex
+++ b/apps/ex_nvr/lib/ex_nvr/recordings.ex
@@ -54,13 +54,9 @@ defmodule ExNVR.Recordings do
 
   @spec get_blob(Device.t(), binary()) :: binary() | nil
   def get_blob(%Device{id: id}, filename) do
-    recording =
-      Recording.with_device(id)
-      |> Recording.with_name(filename)
-      |> Recording.preload_device()
-      |> Repo.one()
-
-    if recording, do: File.read!(recording_path(recording.device, recording))
+    if recording = Repo.one(Recording.get_query(id, filename)) do
+      File.read!(recording_path(recording.device, recording))
+    end
   end
 
   # Runs

--- a/apps/ex_nvr/lib/ex_nvr/recordings/snapshooter.ex
+++ b/apps/ex_nvr/lib/ex_nvr/recordings/snapshooter.ex
@@ -3,17 +3,17 @@ defmodule ExNVR.Recordings.Snapshooter do
   Get a snapshot from a recording
   """
 
-  alias ExNVR.Model.Recording
+  alias ExNVR.Model.{Device, Recording}
   alias ExNVR.MP4.Reader
   alias Membrane.{Buffer, H264}
   alias Membrane.H264.FFmpeg.Decoder
   alias Membrane.Time
 
-  @spec snapshot(Recording.t(), Path.t(), DateTime.t(), Keyword.t()) ::
+  @spec snapshot(Device.t(), Recording.t(), DateTime.t(), Keyword.t()) ::
           {:ok, DateTime.t(), binary()} | {:error, term()}
-  def snapshot(%Recording{} = recording, recording_dir, datetime, opts \\ []) do
+  def snapshot(%Device{} = device, %Recording{} = recording, datetime, opts \\ []) do
     method = Keyword.get(opts, :method, :before)
-    path = Path.join(recording_dir, recording.filename)
+    path = ExNVR.Recordings.recording_path(device, recording)
     seek_time = Time.from_datetime(datetime) - Time.from_datetime(recording.start_date)
 
     with {:ok, mp4_reader} <- Reader.new(path),

--- a/apps/ex_nvr/lib/ex_nvr/upgrade.ex
+++ b/apps/ex_nvr/lib/ex_nvr/upgrade.ex
@@ -1,0 +1,64 @@
+defmodule ExNVR.Upgrade do
+  @moduledoc """
+  Set of functions to upgrade to a new version after introducing breaking changes
+  """
+
+  require Logger
+
+  alias ExNVR.Model.{Device, Recording}
+
+  @app :ex_nvr
+
+  @spec upgrade(binary(), Keyword.t()) :: :ok
+  def upgrade(version, opts \\ []) do
+    Application.load(@app)
+    do_upgrade(version, opts)
+  end
+
+  defp do_upgrade("v0.6.0", opts) do
+    mountpoint = Keyword.fetch!(opts, :mountpoint)
+    recording_dir = Keyword.fetch!(opts, :recording_dir)
+
+    ExNVR.Repo.update_all(Device, [set: [settings: %Device.Settings{storage_address: mountpoint}]])
+    devices = ExNVR.Repo.all(Device)
+
+    Enum.each(devices, &create_device_directories/1)
+    Enum.each(devices, &do_migrate_recordings(&1, recording_dir))
+  end
+
+  defp create_device_directories(device) do
+    File.mkdir_p!(Device.base_dir(device))
+    File.mkdir_p!(Device.recording_dir(device))
+    File.mkdir_p!(Device.recording_dir(device, :low))
+    File.mkdir_p!(Device.bif_dir(device))
+  end
+
+  defp do_migrate_recordings(device, recording_dir) do
+    Logger.info("Migrate device recordings: #{device.id}")
+
+    bif_dir = Path.join([recording_dir, device.id, "bif"])
+
+    Path.join(bif_dir, "*.bif")
+    |> Path.wildcard()
+    |> Enum.each(fn filename ->
+      File.rename!(filename, Path.join(Device.bif_dir(device), Path.basename(filename)))
+    end)
+
+    stream = ExNVR.Repo.stream(Recording.with_device(device.id), timeout: :infinity)
+
+    ExNVR.Repo.transaction(fn ->
+      stream
+      |> Stream.map(fn recording ->
+        src = Path.join([recording_dir, device.id, recording.filename])
+        dest = ExNVR.Recordings.recording_path(device, recording)
+
+        if File.exists?(src) do
+          File.mkdir_p!(Path.dirname(dest))
+          File.rename!(src, dest)
+        end
+      end)
+      |> Stream.run()
+    end)
+
+  end
+end

--- a/apps/ex_nvr/lib/ex_nvr/utils.ex
+++ b/apps/ex_nvr/lib/ex_nvr/utils.ex
@@ -5,10 +5,16 @@ defmodule ExNVR.Utils do
 
   @unix_socket_dir "/tmp/sockets"
 
-  @spec recording_dir(Device.id() | nil) :: Path.t()
-  def recording_dir(device_id \\ nil) do
-    dir = Application.get_env(:ex_nvr, :recording_directory)
-    if device_id, do: Path.join(dir, device_id), else: dir
+  @spec recording_dir(Device.t()) :: Path.t()
+  def recording_dir(device) do
+    case Device.recording_dir(device) do
+      nil ->
+        dir = Application.get_env(:ex_nvr, :recording_directory)
+        Path.join(dir, device.id)
+
+      path ->
+        path
+    end
   end
 
   @spec hls_dir(Device.id() | nil) :: Path.t()
@@ -17,9 +23,9 @@ defmodule ExNVR.Utils do
     if device_id, do: Path.join(dir, device_id), else: dir
   end
 
-  @spec bif_dir(Device.id()) :: Path.t()
-  def bif_dir(device_id) do
-    Path.join(recording_dir(device_id), "bif")
+  @spec bif_dir(Device.t()) :: Path.t()
+  def bif_dir(device) do
+    Path.join(recording_dir(device), "bif")
   end
 
   @spec unix_socket_dir() :: Path.t()

--- a/apps/ex_nvr/lib/ex_nvr/utils.ex
+++ b/apps/ex_nvr/lib/ex_nvr/utils.ex
@@ -5,27 +5,10 @@ defmodule ExNVR.Utils do
 
   @unix_socket_dir "/tmp/sockets"
 
-  @spec recording_dir(Device.t()) :: Path.t()
-  def recording_dir(device) do
-    case Device.recording_dir(device) do
-      nil ->
-        dir = Application.get_env(:ex_nvr, :recording_directory)
-        Path.join(dir, device.id)
-
-      path ->
-        path
-    end
-  end
-
   @spec hls_dir(Device.id() | nil) :: Path.t()
   def hls_dir(device_id \\ nil) do
     dir = Application.get_env(:ex_nvr, :hls_directory)
     if device_id, do: Path.join(dir, device_id), else: dir
-  end
-
-  @spec bif_dir(Device.t()) :: Path.t()
-  def bif_dir(device) do
-    Path.join(recording_dir(device), "bif")
   end
 
   @spec unix_socket_dir() :: Path.t()
@@ -48,4 +31,16 @@ defmodule ExNVR.Utils do
 
   # Streaming & Codecs utilities
   defguard keyframe(buffer) when buffer.metadata.h264.key_frame?
+
+  @spec date_components(DateTime.t()) :: [binary()]
+  def date_components(%DateTime{} = datetime) do
+    [
+      "#{datetime.year}",
+      pad_number(datetime.month),
+      pad_number(datetime.day),
+      pad_number(datetime.hour)
+    ]
+  end
+
+  defp pad_number(number), do: String.pad_leading("#{number}", 2, "0")
 end

--- a/apps/ex_nvr/priv/repo/migrations/20231120200624_add-settings-field-to-device.exs
+++ b/apps/ex_nvr/priv/repo/migrations/20231120200624_add-settings-field-to-device.exs
@@ -1,0 +1,12 @@
+defmodule ExNVR.Repo.Migrations.AddSettingsFieldToDevice do
+  use Ecto.Migration
+
+  def change do
+    alter table("devices") do
+      add :settings, :map, default: %{}
+    end
+
+    drop index("recordings", [:filename], unique: true)
+    create index("recordings", [:device_id, :filename], unique: true)
+  end
+end

--- a/apps/ex_nvr/test/ex_nvr/bif_generator_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/bif_generator_test.exs
@@ -7,8 +7,8 @@ defmodule ExNVR.BifGeneratorTest do
 
   @moduletag :tmp_dir
 
-  setup do
-    device = device_fixture()
+  setup %{tmp_dir: tmp_dir} do
+    device = device_fixture(%{settings: %{storage_address: tmp_dir}})
 
     run_fixture(device,
       start_date: ~U(2023-08-10 10:15:10.000000Z),
@@ -25,9 +25,6 @@ defmodule ExNVR.BifGeneratorTest do
         start_date: ~U(2023-08-12 14:15:10.000000Z),
         end_date: ~U(2023-08-12 16:17:10.000000Z)
       )
-
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
-    File.mkdir_p!(ExNVR.Utils.bif_dir(device))
 
     {:ok, device: device, run: run}
   end

--- a/apps/ex_nvr/test/ex_nvr/bif_generator_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/bif_generator_test.exs
@@ -9,7 +9,7 @@ defmodule ExNVR.BifGeneratorTest do
   @moduletag :tmp_dir
 
   setup %{tmp_dir: tmp_dir} do
-    device = device_fixture(%{settings: %{storage_address: tmp_dir}})
+    device = device_fixture(%{settings: %{storage_address: tmp_dir, generate_bif: true}})
 
     run_fixture(device,
       start_date: ~U(2023-08-10 10:15:10.000000Z),

--- a/apps/ex_nvr/test/ex_nvr/bif_generator_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/bif_generator_test.exs
@@ -4,6 +4,7 @@ defmodule ExNVR.BifGeneratorTest do
   use ExNVR.DataCase
 
   alias ExNVR.BifGeneratorServer
+  alias ExNVR.Model.Device
 
   @moduletag :tmp_dir
 
@@ -39,7 +40,7 @@ defmodule ExNVR.BifGeneratorTest do
              ~U(2023-08-12 16:00:00Z)
            ] = BifGeneratorServer.list_hours(device)
 
-    ExNVR.Utils.bif_dir(device)
+    Device.bif_dir(device)
     |> Path.join("2023081214.bif")
     |> File.touch!()
 
@@ -48,7 +49,7 @@ defmodule ExNVR.BifGeneratorTest do
   end
 
   test "generate bif files", %{device: device, run: run} do
-    ExNVR.Utils.bif_dir(device)
+    Device.bif_dir(device)
     |> Path.join("2023081214.bif")
     |> File.touch!()
 
@@ -69,7 +70,7 @@ defmodule ExNVR.BifGeneratorTest do
     assert {:ok, state} = BifGeneratorServer.init(device: device)
     assert {:noreply, ^state} = BifGeneratorServer.handle_info(:tick, state)
 
-    bif_dir = ExNVR.Utils.bif_dir(device)
+    bif_dir = Device.bif_dir(device)
 
     for hour <- hours do
       filename = Calendar.strftime(hour, "%Y%m%d%H.bif")

--- a/apps/ex_nvr/test/ex_nvr/bif_generator_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/bif_generator_test.exs
@@ -26,8 +26,8 @@ defmodule ExNVR.BifGeneratorTest do
         end_date: ~U(2023-08-12 16:17:10.000000Z)
       )
 
-    File.mkdir!(ExNVR.Utils.recording_dir(device.id))
-    File.mkdir!(ExNVR.Utils.bif_dir(device.id))
+    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
+    File.mkdir_p!(ExNVR.Utils.bif_dir(device))
 
     {:ok, device: device, run: run}
   end
@@ -42,7 +42,7 @@ defmodule ExNVR.BifGeneratorTest do
              ~U(2023-08-12 16:00:00Z)
            ] = BifGeneratorServer.list_hours(device)
 
-    ExNVR.Utils.bif_dir(device.id)
+    ExNVR.Utils.bif_dir(device)
     |> Path.join("2023081214.bif")
     |> File.touch!()
 
@@ -51,7 +51,7 @@ defmodule ExNVR.BifGeneratorTest do
   end
 
   test "generate bif files", %{device: device, run: run} do
-    ExNVR.Utils.bif_dir(device.id)
+    ExNVR.Utils.bif_dir(device)
     |> Path.join("2023081214.bif")
     |> File.touch!()
 
@@ -72,7 +72,7 @@ defmodule ExNVR.BifGeneratorTest do
     assert {:ok, state} = BifGeneratorServer.init(device: device)
     assert {:noreply, ^state} = BifGeneratorServer.handle_info(:tick, state)
 
-    bif_dir = ExNVR.Utils.bif_dir(device.id)
+    bif_dir = ExNVR.Utils.bif_dir(device)
 
     for hour <- hours do
       filename = Calendar.strftime(hour, "%Y%m%d%H.bif")

--- a/apps/ex_nvr/test/ex_nvr/devices_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/devices_test.exs
@@ -152,6 +152,7 @@ defmodule ExNVR.DevicesTest do
       {:ok, device} = Devices.create(valid_device_attributes(%{name: @valid_camera_name}))
       assert device.id
       assert device.name == @valid_camera_name
+      assert Map.from_struct(device.settings) == valid_device_settings()
     end
   end
 

--- a/apps/ex_nvr/test/ex_nvr/devices_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/devices_test.exs
@@ -215,7 +215,7 @@ defmodule ExNVR.DevicesTest do
   describe "change_user_creation/1" do
     test "returns changeset" do
       assert %Ecto.Changeset{} = changeset = Devices.change_device_creation(%Device{})
-      assert changeset.required == [:settings, :name, :type]
+      assert changeset.required == [:name, :type, :settings]
     end
 
     test "requires Stream config (camera config) to be set when type is IP" do
@@ -228,7 +228,7 @@ defmodule ExNVR.DevicesTest do
                  valid_device_attributes(%{name: name, type: "ip"})
                )
 
-      assert changeset.required == [:stream_config, :settings, :name, :type]
+      assert changeset.required == [:stream_config, :name, :type, :settings]
     end
 
     test "allows fields to be set (Type: ip)" do
@@ -267,7 +267,7 @@ defmodule ExNVR.DevicesTest do
                  valid_device_attributes(%{name: name, type: "file"})
                )
 
-      assert changeset.required == [:stream_config, :settings, :name, :type]
+      assert changeset.required == [:stream_config, :name, :type, :settings]
     end
 
     test "allows fields to be set (Type: file)" do

--- a/apps/ex_nvr/test/ex_nvr/devices_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/devices_test.exs
@@ -8,20 +8,30 @@ defmodule ExNVR.DevicesTest do
 
   @valid_camera_name "camera 1"
 
+  @moduletag :tmp_dir
+
+  setup ctx do
+    %{settings: %{storage_address: ctx.tmp_dir}}
+  end
+
   describe "list_devices/1" do
     test "returns empty list if no device exists" do
       assert Enum.empty?(Devices.list())
     end
 
-    test "returns all the devices" do
-      devices = [device_fixture(), device_fixture()]
+    test "returns all the devices", ctx do
+      devices = [
+        device_fixture(%{settings: ctx.settings}),
+        device_fixture(%{settings: ctx.settings})
+      ]
+
       assert devices == Devices.list()
     end
 
-    test "filter devices by state" do
-      device_1 = device_fixture(%{state: :recording})
-      device_2 = device_fixture(%{state: :failed})
-      device_3 = device_fixture(%{state: :stopped})
+    test "filter devices by state", ctx do
+      device_1 = device_fixture(%{state: :recording, settings: ctx.settings})
+      device_2 = device_fixture(%{state: :failed, settings: ctx.settings})
+      device_3 = device_fixture(%{state: :stopped, settings: ctx.settings})
 
       assert [device_1] == Devices.list(%{state: :recording})
       assert [device_2, device_3] == Devices.list(%{state: [:failed, :stopped]})
@@ -146,8 +156,8 @@ defmodule ExNVR.DevicesTest do
   end
 
   describe "update/2" do
-    setup do
-      %{device: device_fixture()}
+    setup ctx do
+      %{device: device_fixture(%{settings: ctx.settings})}
     end
 
     test "type cannot be updated", %{device: device} do
@@ -174,8 +184,8 @@ defmodule ExNVR.DevicesTest do
   end
 
   describe "update_state/2" do
-    setup do
-      %{device: device_fixture()}
+    setup ctx do
+      %{device: device_fixture(%{settings: ctx.settings})}
     end
 
     test "device state updated", %{device: device} do
@@ -273,8 +283,8 @@ defmodule ExNVR.DevicesTest do
     end
   end
 
-  test "get recordings dir" do
-    device = device_fixture()
-    assert "/tmp/recordings/#{device.id}" == Device.recording_dir(device)
+  test "get recordings dir", ctx do
+    device = device_fixture(%{settings: ctx.settings})
+    assert Path.join([ctx.tmp_dir, "recordings", device.id]) == Device.recording_dir(device)
   end
 end

--- a/apps/ex_nvr/test/ex_nvr/elements/recording_pipeline_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/elements/recording_pipeline_test.exs
@@ -13,7 +13,7 @@ defmodule ExNVR.Elements.RecordingPipelineTest do
 
   setup do
     device = device_fixture()
-    File.mkdir!(ExNVR.Utils.recording_dir(device.id))
+    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
 
     recording_fixture(device,
       start_date: ~U(2023-09-06 10:00:00Z),
@@ -127,14 +127,13 @@ defmodule ExNVR.Elements.RecordingPipelineTest do
        ) do
     structure = [
       child(:source, %RecordingBin{
-        device_id: device.id,
+        device: device,
         start_date: start_date,
         end_date: end_date,
         strategy: strategy,
         duration: duration
       })
       |> via_out(:video)
-      # |> child(:filer, %Membrane.Debug.Filter{handle_buffer: &IO.inspect/1})
       |> child(:sink, %Membrane.File.Sink{location: out_file})
     ]
 

--- a/apps/ex_nvr/test/ex_nvr/elements/recording_pipeline_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/elements/recording_pipeline_test.exs
@@ -11,9 +11,8 @@ defmodule ExNVR.Elements.RecordingPipelineTest do
 
   @moduletag :tmp_dir
 
-  setup do
-    device = device_fixture()
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
+  setup %{tmp_dir: tmp_dir} do
+    device = device_fixture(%{settings: %{storage_address: tmp_dir}})
 
     recording_fixture(device,
       start_date: ~U(2023-09-06 10:00:00Z),

--- a/apps/ex_nvr/test/ex_nvr/pipeline/output/socket/socket_pipeline_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipeline/output/socket/socket_pipeline_test.exs
@@ -17,6 +17,7 @@ defmodule ExNVR.Pipeline.Output.SocketPipelineTest do
   if :os.type() |> elem(0) == :unix do
     test "snapshots are sent to unix socket", %{tmp_dir: tmp_dir} do
       device = device_fixture(%{settings: %{storage_address: tmp_dir}})
+      File.mkdir_p!(Utils.unix_socket_dir())
       Process.register(self(), Utils.pipeline_name(device))
       {:ok, _server} = UnixSocketServer.start_link(device: device)
 

--- a/apps/ex_nvr/test/ex_nvr/pipeline/output/socket/socket_pipeline_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipeline/output/socket/socket_pipeline_test.exs
@@ -15,9 +15,8 @@ defmodule ExNVR.Pipeline.Output.SocketPipelineTest do
   @moduletag :tmp_dir
 
   if :os.type() |> elem(0) == :unix do
-    test "snapshots are sent to unix socket" do
-      device = device_fixture()
-      File.mkdir_p!(Utils.unix_socket_dir())
+    test "snapshots are sent to unix socket", %{tmp_dir: tmp_dir} do
+      device = device_fixture(%{settings: %{storage_address: tmp_dir}})
       Process.register(self(), Utils.pipeline_name(device))
       {:ok, _server} = UnixSocketServer.start_link(device: device)
 

--- a/apps/ex_nvr/test/ex_nvr/pipeline/output/storage/storage_pipeline_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipeline/output/storage/storage_pipeline_test.exs
@@ -34,9 +34,9 @@ defmodule ExNVR.Pipeline.Output.StoragePipelineTest do
     assert {:ok, {recordings, _meta}} = ExNVR.Recordings.list()
     assert length(recordings) == 3
 
-    assert recording_path(device, segment1.start_date) |> File.exists?()
-    assert recording_path(device, segment2.start_date) |> File.exists?()
-    assert recording_path(device, segment3.start_date) |> File.exists?()
+    assert ExNVR.Recordings.recording_path(device, segment1) |> File.exists?()
+    assert ExNVR.Recordings.recording_path(device, segment2) |> File.exists?()
+    assert ExNVR.Recordings.recording_path(device, segment3) |> File.exists?()
 
     Pipeline.terminate(pid)
   end
@@ -61,11 +61,5 @@ defmodule ExNVR.Pipeline.Output.StoragePipelineTest do
     |> :binary.bin_to_list()
     |> Enum.chunk_every(500)
     |> Enum.map(&:binary.list_to_bin/1)
-  end
-
-  defp recording_path(device, start_date) do
-    device
-    |> ExNVR.Utils.recording_dir()
-    |> Path.join("#{DateTime.to_unix(start_date, :microsecond)}.mp4")
   end
 end

--- a/apps/ex_nvr/test/ex_nvr/pipeline/output/storage/storage_pipeline_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipeline/output/storage/storage_pipeline_test.exs
@@ -14,9 +14,8 @@ defmodule ExNVR.Pipeline.Output.StoragePipelineTest do
 
   @fixture_path "../../../../fixtures/video-30-10s.h264" |> Path.expand(__DIR__)
 
-  setup do
-    device = device_fixture()
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
+  setup %{tmp_dir: tmp_dir} do
+    device = device_fixture(%{settings: %{storage_address: tmp_dir}})
 
     %{device: device}
   end

--- a/apps/ex_nvr/test/ex_nvr/pipelines/bif_generator_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/bif_generator_test.exs
@@ -9,8 +9,7 @@ defmodule ExNVR.Pipelines.BifGeneratorTest do
 
   setup do
     device = device_fixture()
-
-    File.mkdir!(ExNVR.Utils.recording_dir(device.id))
+    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
 
     recording_fixture(device,
       start_date: ~U(2023-06-23 10:00:00Z),
@@ -53,9 +52,7 @@ defmodule ExNVR.Pipelines.BifGeneratorTest do
   defp prepare_pipeline(device, options) do
     options = [
       module: ExNVR.Pipelines.BifGenerator,
-      custom_args:
-        [device_id: device.id]
-        |> Keyword.merge(options)
+      custom_args: Keyword.merge([device: device], options)
     ]
 
     Testing.Pipeline.start_supervised!(options)

--- a/apps/ex_nvr/test/ex_nvr/pipelines/bif_generator_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/bif_generator_test.exs
@@ -7,9 +7,8 @@ defmodule ExNVR.Pipelines.BifGeneratorTest do
 
   @moduletag :tmp_dir
 
-  setup do
-    device = device_fixture()
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
+  setup ctx do
+    device = device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})
 
     recording_fixture(device,
       start_date: ~U(2023-06-23 10:00:00Z),

--- a/apps/ex_nvr/test/ex_nvr/pipelines/hls_playback_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/hls_playback_test.exs
@@ -13,8 +13,7 @@ defmodule ExNVR.Pipelines.HlsPlaybackTest do
 
   setup do
     device = device_fixture()
-
-    File.mkdir!(ExNVR.Utils.recording_dir(device.id))
+    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
 
     recording_fixture(device,
       start_date: ~U(2023-06-23 10:00:00Z),
@@ -48,7 +47,7 @@ defmodule ExNVR.Pipelines.HlsPlaybackTest do
     options = [
       module: ExNVR.Pipelines.HlsPlayback,
       custom_args:
-        [device_id: device.id, start_date: ~U(2023-06-23 10:00:02Z)] |> Keyword.merge(options)
+        [device: device, start_date: ~U(2023-06-23 10:00:02Z)] |> Keyword.merge(options)
     ]
 
     Testing.Pipeline.start_supervised!(options)

--- a/apps/ex_nvr/test/ex_nvr/pipelines/hls_playback_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/hls_playback_test.exs
@@ -11,9 +11,8 @@ defmodule ExNVR.Pipelines.HlsPlaybackTest do
 
   @moduletag :tmp_dir
 
-  setup do
-    device = device_fixture()
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
+  setup ctx do
+    device = device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})
 
     recording_fixture(device,
       start_date: ~U(2023-06-23 10:00:00Z),

--- a/apps/ex_nvr/test/ex_nvr/pipelines/snapshot_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/snapshot_test.exs
@@ -12,8 +12,7 @@ defmodule ExNVR.Pipelines.SnapshotTest do
 
   setup do
     device = device_fixture()
-
-    File.mkdir!(ExNVR.Utils.recording_dir(device.id))
+    File.mkdir!(ExNVR.Utils.recording_dir(device))
 
     recording =
       recording_fixture(device,
@@ -27,7 +26,7 @@ defmodule ExNVR.Pipelines.SnapshotTest do
   defp perform_test(device, recording, ref_path, method \\ :before) do
     assert {:ok, _sup_pid, _pid} =
              Pipelines.Snapshot.start(
-               device_id: device.id,
+               device: device,
                date: DateTime.add(recording.start_date, 3),
                method: method
              )

--- a/apps/ex_nvr/test/ex_nvr/pipelines/snapshot_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/snapshot_test.exs
@@ -10,9 +10,8 @@ defmodule ExNVR.Pipelines.SnapshotTest do
 
   @moduletag :tmp_dir
 
-  setup do
-    device = device_fixture()
-    File.mkdir!(ExNVR.Utils.recording_dir(device))
+  setup ctx do
+    device = device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})
 
     recording =
       recording_fixture(device,

--- a/apps/ex_nvr/test/ex_nvr/pipelines/video_assembler_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/video_assembler_test.exs
@@ -71,7 +71,7 @@ defmodule ExNVR.Pipelines.VideoAssemblerTest do
       rec =
         Enum.map(
           recordings,
-          &Recording.Download.new(&1, ExNVR.Utils.recording_dir(device))
+          &Recording.Download.new(&1, ExNVR.Recordings.recording_path(device, &1))
         )
 
       start_date = DateTime.to_unix(~U(2023-06-23 10:00:03Z), :millisecond)

--- a/apps/ex_nvr/test/ex_nvr/pipelines/video_assembler_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/video_assembler_test.exs
@@ -14,8 +14,7 @@ defmodule ExNVR.Pipelines.VideoAssemblerTest do
 
   setup do
     device = device_fixture()
-
-    File.mkdir!(ExNVR.Utils.recording_dir(device.id))
+    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
 
     recording1 =
       recording_fixture(device,
@@ -73,7 +72,7 @@ defmodule ExNVR.Pipelines.VideoAssemblerTest do
       rec =
         Enum.map(
           recordings,
-          &Recording.Download.new(&1, ExNVR.Utils.recording_dir(device.id))
+          &Recording.Download.new(&1, ExNVR.Utils.recording_dir(device))
         )
 
       start_date = DateTime.to_unix(~U(2023-06-23 10:00:03Z), :millisecond)
@@ -97,9 +96,7 @@ defmodule ExNVR.Pipelines.VideoAssemblerTest do
   defp prepare_pipeline(device, options) do
     options = [
       module: ExNVR.Pipelines.VideoAssembler,
-      custom_args:
-        [device_id: device.id]
-        |> Keyword.merge(options)
+      custom_args: Keyword.merge([device: device], options)
     ]
 
     Testing.Pipeline.start_supervised!(options)

--- a/apps/ex_nvr/test/ex_nvr/pipelines/video_assembler_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/pipelines/video_assembler_test.exs
@@ -12,9 +12,8 @@ defmodule ExNVR.Pipelines.VideoAssemblerTest do
 
   @moduletag :tmp_dir
 
-  setup do
-    device = device_fixture()
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
+  setup ctx do
+    device = device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})
 
     recording1 =
       recording_fixture(device,

--- a/apps/ex_nvr/test/ex_nvr/recordings/snapshooter_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/recordings/snapshooter_test.exs
@@ -10,8 +10,7 @@ defmodule ExNVR.Recordings.SnapshooterTest do
 
   setup do
     device = device_fixture()
-
-    File.mkdir!(ExNVR.Utils.recording_dir(device.id))
+    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
 
     recording =
       recording_fixture(device,
@@ -31,7 +30,7 @@ defmodule ExNVR.Recordings.SnapshooterTest do
     assert {:ok, timestamp, snapshot} =
              ExNVR.Recordings.Snapshooter.snapshot(
                recording,
-               ExNVR.Utils.recording_dir(device.id),
+               ExNVR.Utils.recording_dir(device),
                ~U(2023-06-23 10:00:03Z)
              )
 
@@ -54,7 +53,7 @@ defmodule ExNVR.Recordings.SnapshooterTest do
     assert {:ok, start_date, snapshot} =
              ExNVR.Recordings.Snapshooter.snapshot(
                recording,
-               ExNVR.Utils.recording_dir(device.id),
+               ExNVR.Utils.recording_dir(device),
                datetime,
                method: :precise
              )

--- a/apps/ex_nvr/test/ex_nvr/recordings/snapshooter_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/recordings/snapshooter_test.exs
@@ -28,8 +28,8 @@ defmodule ExNVR.Recordings.SnapshooterTest do
 
     assert {:ok, timestamp, snapshot} =
              ExNVR.Recordings.Snapshooter.snapshot(
+               device,
                recording,
-               ExNVR.Utils.recording_dir(device),
                ~U(2023-06-23 10:00:03Z)
              )
 
@@ -51,8 +51,8 @@ defmodule ExNVR.Recordings.SnapshooterTest do
 
     assert {:ok, start_date, snapshot} =
              ExNVR.Recordings.Snapshooter.snapshot(
+               device,
                recording,
-               ExNVR.Utils.recording_dir(device),
                datetime,
                method: :precise
              )

--- a/apps/ex_nvr/test/ex_nvr/recordings/snapshooter_test.exs
+++ b/apps/ex_nvr/test/ex_nvr/recordings/snapshooter_test.exs
@@ -8,9 +8,8 @@ defmodule ExNVR.Recordings.SnapshooterTest do
 
   @moduletag :tmp_dir
 
-  setup do
-    device = device_fixture()
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
+  setup ctx do
+    device = device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})
 
     recording =
       recording_fixture(device,

--- a/apps/ex_nvr/test/support/fixtures/devices_fixtures.ex
+++ b/apps/ex_nvr/test/support/fixtures/devices_fixtures.ex
@@ -46,9 +46,6 @@ defmodule ExNVR.DevicesFixtures do
       |> valid_device_attributes(device_type)
       |> ExNVR.Devices.create()
 
-    File.mkdir_p!(Device.recording_dir(device))
-    File.mkdir_p!(ExNVR.Utils.bif_dir(device))
-
     device
   end
 

--- a/apps/ex_nvr/test/support/fixtures/devices_fixtures.ex
+++ b/apps/ex_nvr/test/support/fixtures/devices_fixtures.ex
@@ -4,14 +4,18 @@ defmodule ExNVR.DevicesFixtures do
   entities via the `ExNVR.Devices` context.
   """
 
+  @spec valid_rtsp_url() :: binary()
   def valid_rtsp_url(), do: "rtsp://example#{System.unique_integer()}:8541"
 
+  @spec valid_file_location() :: Path.t()
   def valid_file_location(), do: "../../fixtures/big_buck.mp4" |> Path.expand(__DIR__)
   def invalid_file_extenstion(), do: "../../fixtures/video-30-10s.h264" |> Path.expand(__DIR__)
 
+  @spec valid_device_name() :: binary()
   def valid_device_name(), do: "Device_#{System.unique_integer([:monotonic, :positive])}"
 
   def valid_device_credentials(), do: %{username: "user", password: "pass"}
+  def valid_device_settings(), do: %{generate_bif: false, storage_address: "/tmp"}
 
   def valid_device_attributes(attrs \\ %{}, type \\ "ip") do
     {stream_config, attrs} = Map.pop(attrs, :stream_config, %{})
@@ -25,10 +29,12 @@ defmodule ExNVR.DevicesFixtures do
       timezone: "UTC",
       state: :recording,
       stream_config: stream_config,
-      credentials: credentials
+      credentials: credentials,
+      settings: valid_device_settings()
     })
   end
 
+  @spec device_fixture(map(), binary()) :: ExNVR.Model.Device.t()
   def device_fixture(attrs \\ %{}, device_type \\ "ip") do
     {:ok, device} =
       attrs

--- a/apps/ex_nvr/test/support/fixtures/recordings_fixtures.ex
+++ b/apps/ex_nvr/test/support/fixtures/recordings_fixtures.ex
@@ -29,6 +29,7 @@ defmodule ExNVR.RecordingsFixtures do
       attrs
       |> Enum.into(%{device_id: device.id})
       |> valid_recording_attributes()
+      |> tap(&File.mkdir_p!(Path.dirname(ExNVR.Recordings.recording_path(device, &1))))
       |> then(&ExNVR.Recordings.create(device, attrs[:run] || run_fixture(device), &1))
 
     recording

--- a/apps/ex_nvr/test/support/fixtures/recordings_fixtures.ex
+++ b/apps/ex_nvr/test/support/fixtures/recordings_fixtures.ex
@@ -29,7 +29,7 @@ defmodule ExNVR.RecordingsFixtures do
       attrs
       |> Enum.into(%{device_id: device.id})
       |> valid_recording_attributes()
-      |> then(&ExNVR.Recordings.create(attrs[:run] || run_fixture(device), &1))
+      |> then(&ExNVR.Recordings.create(device, attrs[:run] || run_fixture(device), &1))
 
     recording
   end

--- a/apps/ex_nvr_web/lib/ex_nvr_web/components/core_components.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/components/core_components.ex
@@ -304,6 +304,30 @@ defmodule ExNVRWeb.CoreComponents do
     """
   end
 
+  def input(%{type: "radio"} = assigns) do
+    ~H"""
+    <div phx-feedback-for={@name}>
+      <label class="flex items-center gap-4 text-sm leading-6 text-zinc-600 dark:text-white">
+        <input
+          type="radio"
+          id={@id}
+          name={@name}
+          class={[
+            "rounded text-zinc-900 border-gray-300 rounded bg-gray-50 focus:ring-3 focus:ring-blue-300",
+            "dark:bg-gray-700 dark:border-gray-600 dark:focus:ring-blue-600",
+            "dark:ring-offset-gray-800 dark:focus:ring-offset-gray-80"
+          ]}
+          value={@value}
+          checked={@checked}
+          {@rest}
+        />
+        <%= @label %>
+      </label>
+      <.error :for={msg <- @errors}><%= msg %></.error>
+    </div>
+    """
+  end
+
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name}>

--- a/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_json.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_json.ex
@@ -15,5 +15,6 @@ defmodule ExNVRWeb.API.DeviceJSON do
     |> Map.take([:id, :name, :type, :state, :timezone, :inserted_at, :updated_at])
     |> Map.put(:stream_config, Map.from_struct(device.stream_config))
     |> Map.put(:credentials, Map.from_struct(device.credentials))
+    |> Map.put(:settings, Map.from_struct(device.settings))
   end
 end

--- a/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_streaming_controller.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_streaming_controller.ex
@@ -162,7 +162,7 @@ defmodule ExNVRWeb.API.DeviceStreamingController do
   def bif(conn, params) do
     with {:ok, params} <- validate_bif_req_params(params) do
       filename = Calendar.strftime(params.hour, "%Y%m%d%H.bif")
-      filepath = Path.join(Utils.bif_dir(conn.assigns.device), filename)
+      filepath = Path.join(ExNVR.Model.Device.bif_dir(conn.assigns.device), filename)
 
       if File.exists?(filepath) do
         send_download(conn, {:file, filepath}, filename: filename)

--- a/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_streaming_controller.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_streaming_controller.ex
@@ -87,11 +87,10 @@ defmodule ExNVRWeb.API.DeviceStreamingController do
 
   defp serve_snapshot_from_recorded_videos(conn, %{time: time} = params) do
     device = conn.assigns.device
-    recording_dir = ExNVR.Utils.recording_dir(device)
 
     with [recording] <- Recordings.get_recordings_between(device.id, time, time),
          {:ok, timestamp, snapshot} <-
-           Recordings.Snapshooter.snapshot(recording, recording_dir, time, method: params.method) do
+           Recordings.Snapshooter.snapshot(device, recording, time, method: params.method) do
       conn
       |> put_resp_header("x-timestamp", "#{DateTime.to_unix(timestamp, :millisecond)}")
       |> put_resp_content_type("image/jpeg")
@@ -153,7 +152,7 @@ defmodule ExNVRWeb.API.DeviceStreamingController do
         {:ok,
          Enum.map(
            recordings,
-           &Recording.Download.new(&1, ExNVR.Utils.recording_dir(device))
+           &Recording.Download.new(&1, Recordings.recording_path(device, &1))
          )}
     end
   end

--- a/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_streaming_controller.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_streaming_controller.ex
@@ -87,7 +87,7 @@ defmodule ExNVRWeb.API.DeviceStreamingController do
 
   defp serve_snapshot_from_recorded_videos(conn, %{time: time} = params) do
     device = conn.assigns.device
-    recording_dir = ExNVR.Utils.recording_dir(device.id)
+    recording_dir = ExNVR.Utils.recording_dir(device)
 
     with [recording] <- Recordings.get_recordings_between(device.id, time, time),
          {:ok, timestamp, snapshot} <-
@@ -153,7 +153,7 @@ defmodule ExNVRWeb.API.DeviceStreamingController do
         {:ok,
          Enum.map(
            recordings,
-           &Recording.Download.new(&1, ExNVR.Utils.recording_dir(device.id))
+           &Recording.Download.new(&1, ExNVR.Utils.recording_dir(device))
          )}
     end
   end
@@ -162,7 +162,7 @@ defmodule ExNVRWeb.API.DeviceStreamingController do
   def bif(conn, params) do
     with {:ok, params} <- validate_bif_req_params(params) do
       filename = Calendar.strftime(params.hour, "%Y%m%d%H.bif")
-      filepath = Path.join(Utils.bif_dir(conn.assigns.device.id), filename)
+      filepath = Path.join(Utils.bif_dir(conn.assigns.device), filename)
 
       if File.exists?(filepath) do
         send_download(conn, {:file, filepath}, filename: filename)

--- a/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_streaming_controller.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/controllers/api/device_streaming_controller.ex
@@ -259,7 +259,7 @@ defmodule ExNVRWeb.API.DeviceStreamingController do
       |> Path.join(stream_id)
 
     pipeline_options = [
-      device_id: device.id,
+      device: device,
       start_date: params.pos,
       resolution: params.resolution,
       directory: path,

--- a/apps/ex_nvr_web/lib/ex_nvr_web/live/device_live.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/live/device_live.ex
@@ -83,10 +83,6 @@ defmodule ExNVRWeb.DeviceLive do
     end
   end
 
-  defp format_disk_entry({mountpoint, total_space, percent_free}) do
-    "#{mountpoint} (capacity: #{humanize_capacity(total_space)}, free: #{percent_free}%)"
-  end
-
   defp humanize_capacity(capacity) do
     cond do
       capacity / 1_000_000_000 >= 1 -> "#{Float.round(capacity / 1024 ** 3, 2)} TiB"

--- a/apps/ex_nvr_web/lib/ex_nvr_web/live/device_live.html.heex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/live/device_live.html.heex
@@ -127,9 +127,26 @@
                       type="radio"
                       value={elem(disk_entry, 0)}
                       checked={elem(disk_entry, 0) == settings[:storage_address].value}
-                      label={format_disk_entry(disk_entry)}
                       disabled={not is_nil(@device.id)}
                     />
+                    <div class="w-full px-2 font-normal text-xs">
+                      <div class="flex justify-between mb-1">
+                        <span class="text-blue-700 dark:text-white">
+                          <%= elem(disk_entry, 0) %>
+                        </span>
+                        <span class="text-blue-700 dark:text-white">
+                          <%= humanize_capacity(elem(disk_entry, 1)) %>
+                        </span>
+                      </div>
+                      <div class="w-full bg-gray-200 rounded-full dark:bg-gray-700">
+                        <div
+                          class="bg-blue-600 text-xs font-medium text-blue-100 text-center leading-none rounded-full"
+                          style={"width: #{elem(disk_entry, 2)}%"}
+                        >
+                          <%= elem(disk_entry, 2) %>%
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </li>
               </ul>

--- a/apps/ex_nvr_web/lib/ex_nvr_web/live/device_live.html.heex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/live/device_live.html.heex
@@ -106,6 +106,42 @@
           </div>
         </div>
       </div>
+
+      <div id="device-settings" class="flex flex-col">
+        <p class="text-xl font-medium mb-4 text-gray-800 dark:text-white">
+          Device Settings
+        </p>
+        <div class="flex flex-col text-gray-900 dark:text-white">
+          <.inputs_for :let={settings} field={@device_form[:settings]}>
+            <div class="w-full mb-5 font-medium bg-white dark:bg-gray-800">
+              <h2 class="mb-2">Select storage address</h2>
+              <ul class="border border-gray-200 rounded-lg dark:border-gray-600">
+                <li
+                  :for={disk_entry <- @disks_data}
+                  class="p-2 w-full border-b border-gray-200 rounded-t-lg dark:border-gray-600"
+                >
+                  <div class="flex items-center ps-3">
+                    <.input
+                      field={settings[:storage_address]}
+                      id="settings-storage-address"
+                      type="radio"
+                      value={elem(disk_entry, 0)}
+                      checked={elem(disk_entry, 0) == settings[:storage_address].value}
+                      label={format_disk_entry(disk_entry)}
+                      disabled={not is_nil(@device.id)}
+                    />
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <h2>Other settings</h2>
+            <div class="mx-3 px-3">
+              <.input field={settings[:generate_bif]} type="checkbox" label="Generate BIF" />
+            </div>
+          </.inputs_for>
+        </div>
+      </div>
       <:actions>
         <.button :if={is_nil(@device.id)} class="w-full" phx-disable-with="Creating...">
           Create

--- a/apps/ex_nvr_web/priv/static/openapi.yaml
+++ b/apps/ex_nvr_web/priv/static/openapi.yaml
@@ -111,7 +111,9 @@ paths:
                   $ref: "#/components/schemas/StreamConfig"
                 credentials:
                   $ref: "#/components/schemas/Credentials"
-              required: [name, type]
+                settings:
+                  $ref: "#/components/schemas/DeviceSettings"
+              required: [name, type, settings]
       responses:
         '201':
           description: Created
@@ -178,6 +180,8 @@ paths:
                   $ref: "#/components/schemas/StreamConfig"
                 credentials:
                   $ref: "#/components/schemas/Credentials"
+                settings:
+                  $ref: "#/components/schemas/DeviceSettings"
       responses:
         '200':
           description: Success
@@ -526,6 +530,8 @@ components:
           $ref: "#/components/schemas/StreamConfig"
         credentials:
           $ref: "#/components/schemas/Credentials"
+        settings:
+          $ref: "#/components/schemas/DeviceSettings"
     StreamConfig:
       type: object
       description: Device stream configuration
@@ -553,6 +559,21 @@ components:
           type: string
           format: password
           description: Password to authenticate
+    DeviceSettings:
+      type: object
+      description: Device settings that controls how the device behaves.
+      properties:
+        generate_bif:
+          type: boolean
+          default: true
+          description: Indicates whether BIF (Base Index File) used for trick play should be generated.
+        storage_address:
+          type: string
+          description: | 
+            The mountpoint/folder where to store device data (recordings, bif, ...etc.)
+
+            This setting is not updatable after the creation of the device
+      required: [storage_address]
     Error:
       type: object
       properties:

--- a/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/device_controller_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/device_controller_test.exs
@@ -7,6 +7,8 @@ defmodule ExNVRWeb.API.DeviceControllerTest do
 
   alias ExNVR.Devices
 
+  @moduletag :tmp_dir
+
   setup %{conn: conn} do
     %{conn: log_in_user_with_access_token(conn, user_fixture())}
   end
@@ -33,8 +35,8 @@ defmodule ExNVRWeb.API.DeviceControllerTest do
   end
 
   describe "PUT/PATCH /api/devices/:id" do
-    setup do
-      %{device: device_fixture()}
+    setup ctx do
+      %{device: device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})}
     end
 
     test "update a device", %{conn: conn, device: device} do
@@ -59,10 +61,10 @@ defmodule ExNVRWeb.API.DeviceControllerTest do
       assert response == []
     end
 
-    test "get all devices (existing devices)", %{conn: conn} do
+    test "get all devices (existing devices)", %{conn: conn, tmp_dir: tmp_dir} do
       devices =
         Enum.map(1..10, fn _ ->
-          device_fixture()
+          device_fixture(%{settings: %{storage_address: tmp_dir}})
         end)
 
       total_devices = devices |> length()
@@ -77,8 +79,8 @@ defmodule ExNVRWeb.API.DeviceControllerTest do
   end
 
   describe "GET /api/devices/:id" do
-    setup do
-      %{device: device_fixture()}
+    setup ctx do
+      %{device: device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})}
     end
 
     test "get device", %{conn: conn, device: device} do

--- a/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/device_streaming_controller_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/device_streaming_controller_test.exs
@@ -96,8 +96,11 @@ defmodule ExNVRWeb.API.DeviceStreamingControllerTest do
       |> response(404)
     end
 
-    test "Returns 404 if the device is not recording when requesting live snapshot", %{conn: conn} do
-      device = device_fixture(%{state: :failed})
+    test "Returns 404 if the device is not recording when requesting live snapshot", %{
+      conn: conn,
+      tmp_dir: tmp_dir
+    } do
+      device = device_fixture(%{state: :failed, settings: %{storage_address: tmp_dir}})
 
       conn
       |> get("/api/devices/#{device.id}/snapshot")

--- a/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/device_streaming_controller_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/device_streaming_controller_test.exs
@@ -198,7 +198,7 @@ defmodule ExNVRWeb.API.DeviceStreamingControllerTest do
 
   describe "GET /api/devices/:device_id/bif/:hour" do
     setup %{device: device} do
-      Path.join(ExNVR.Utils.bif_dir(device), "2023083110.bif") |> File.touch!()
+      Path.join(ExNVR.Model.Device.bif_dir(device), "2023083110.bif") |> File.touch!()
     end
 
     test "Get bif file", %{conn: conn, device: device} do

--- a/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/device_streaming_controller_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/device_streaming_controller_test.exs
@@ -195,7 +195,7 @@ defmodule ExNVRWeb.API.DeviceStreamingControllerTest do
 
   describe "GET /api/devices/:device_id/bif/:hour" do
     setup %{device: device} do
-      Path.join(ExNVR.Utils.bif_dir(device.id), "2023083110.bif") |> File.touch!()
+      Path.join(ExNVR.Utils.bif_dir(device), "2023083110.bif") |> File.touch!()
     end
 
     test "Get bif file", %{conn: conn, device: device} do

--- a/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/recording_controller_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/recording_controller_test.exs
@@ -6,11 +6,10 @@ defmodule ExNVRWeb.API.RecordingControllerTest do
 
   @moduletag :tmp_dir
 
-  setup do
+  setup ctx do
     conn = build_conn() |> log_in_user_with_access_token(AccountsFixtures.user_fixture())
-    device = DevicesFixtures.device_fixture()
+    device = DevicesFixtures.device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})
 
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
     %{conn: conn, device: device}
   end
 

--- a/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/recording_controller_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/controllers/api/recording_controller_test.exs
@@ -10,7 +10,7 @@ defmodule ExNVRWeb.API.RecordingControllerTest do
     conn = build_conn() |> log_in_user_with_access_token(AccountsFixtures.user_fixture())
     device = DevicesFixtures.device_fixture()
 
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device.id))
+    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
     %{conn: conn, device: device}
   end
 

--- a/apps/ex_nvr_web/test/ex_nvr_web/live/dashboard_live_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/live/dashboard_live_test.exs
@@ -21,9 +21,9 @@ defmodule ExNVRWeb.DashboardTest do
       assert path == ~p"/devices"
     end
 
+    @tag :tmp_dir
+    @tag :device
     test "render dashboard page (with devices)", %{conn: conn} do
-      device_fixture()
-
       {:ok, lv, html} = live(conn, ~p"/dashboard")
 
       assert html =~ "Device"
@@ -38,9 +38,16 @@ defmodule ExNVRWeb.DashboardTest do
   end
 
   describe "switch device" do
-    test "switch devices update available streams", %{conn: conn} do
-      device_1 = device_fixture()
-      device_2 = device_fixture(%{stream_config: %{sub_stream_uri: valid_rtsp_url()}})
+    @describetag :tmp_dir
+
+    test "switch devices update available streams", %{conn: conn, tmp_dir: tmp_dir} do
+      device_1 = device_fixture(%{settings: %{storage_address: tmp_dir}})
+
+      device_2 =
+        device_fixture(%{
+          settings: %{storage_address: tmp_dir},
+          stream_config: %{sub_stream_uri: valid_rtsp_url()}
+        })
 
       {:ok, lv, html} = live(conn, ~p"/dashboard")
 
@@ -60,9 +67,10 @@ defmodule ExNVRWeb.DashboardTest do
   end
 
   describe "download footage" do
-    test "end date field is shown if custom duration selected", %{conn: conn} do
-      device_fixture()
+    @describetag :tmp_dir
+    @describetag :device
 
+    test "end date field is shown if custom duration selected", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/dashboard")
 
       html =
@@ -74,8 +82,6 @@ defmodule ExNVRWeb.DashboardTest do
     end
 
     test "no footage", %{conn: conn} do
-      device_fixture()
-
       {:ok, lv, _html} = live(conn, ~p"/dashboard")
 
       html =
@@ -87,8 +93,6 @@ defmodule ExNVRWeb.DashboardTest do
       refute html =~ "End Date"
     end
 
-    @tag :device
-    @tag :tmp_dir
     test "no errors", %{conn: conn, device: device} do
       recording_fixture(device, start_date: ~U(2023-10-05T10:00:00Z))
 

--- a/apps/ex_nvr_web/test/ex_nvr_web/live/device_list_live_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/live/device_list_live_test.exs
@@ -5,9 +5,11 @@ defmodule ExNVRWeb.DeviceListLiveTest do
   import ExNVR.{AccountsFixtures, DevicesFixtures}
   import Phoenix.LiveViewTest
 
+  @moduletag :tmp_dir
+
   describe "Device list page" do
-    setup do
-      %{device: device_fixture()}
+    setup ctx do
+      %{device: device_fixture(%{settings: %{storage_address: ctx.tmp_dir}})}
     end
 
     test "render devices page", %{conn: conn, device: device} do
@@ -50,8 +52,8 @@ defmodule ExNVRWeb.DeviceListLiveTest do
       %{conn: log_in_user(conn, user_fixture())}
     end
 
-    test "Stop recording", %{conn: conn} do
-      device = device_fixture(%{state: :recording})
+    test "Stop recording", %{conn: conn, tmp_dir: tmp_dir} do
+      device = device_fixture(%{state: :recording, settings: %{storage_address: tmp_dir}})
 
       {:ok, lv, html} = live(conn, ~p"/devices")
 
@@ -66,8 +68,8 @@ defmodule ExNVRWeb.DeviceListLiveTest do
       assert ExNVR.Devices.get!(device.id).state == :stopped
     end
 
-    test "Start recording", %{conn: conn} do
-      device = device_fixture(%{state: :stopped})
+    test "Start recording", %{conn: conn, tmp_dir: tmp_dir} do
+      device = device_fixture(%{state: :stopped, settings: %{storage_address: tmp_dir}})
 
       {:ok, lv, html} = live(conn, ~p"/devices")
 

--- a/apps/ex_nvr_web/test/ex_nvr_web/live/device_live_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/live/device_live_test.exs
@@ -43,7 +43,8 @@ defmodule ExNVRWeb.DeviceLiveTest do
             "type" => "file",
             "stream_config" => %{
               "location" => valid_file_location()
-            }
+            },
+            "settings" => %{"storage_address" => "/tmp"}
           }
         })
         |> render_submit()
@@ -61,7 +62,8 @@ defmodule ExNVRWeb.DeviceLiveTest do
           "device" => %{
             "name" => "My Device",
             "type" => "file",
-            "stream_config" => %{"location" => "rtsp://"}
+            "stream_config" => %{"location" => "rtsp://"},
+            "settings" => %{"storage_address" => "/tmp"}
           }
         })
         |> render_submit()
@@ -85,6 +87,9 @@ defmodule ExNVRWeb.DeviceLiveTest do
             },
             "stream_config" => %{
               "stream_uri" => "rtsp://localhost:554"
+            },
+            "settings" => %{
+              "storage_address" => "/tmp"
             }
           }
         })
@@ -103,7 +108,8 @@ defmodule ExNVRWeb.DeviceLiveTest do
           "device" => %{
             "name" => "My Device",
             "type" => "ip",
-            "stream_config" => %{"stream_uri" => "rtsp://"}
+            "stream_config" => %{"stream_uri" => "rtsp://"},
+            "settings" => %{"storage_address" => "/tmp"}
           }
         })
         |> render_submit()

--- a/apps/ex_nvr_web/test/ex_nvr_web/live/device_live_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/live/device_live_test.exs
@@ -8,6 +8,8 @@ defmodule ExNVRWeb.DeviceLiveTest do
 
   alias ExNVR.Devices
 
+  @moduletag :tmp_dir
+
   setup %{conn: conn} do
     %{conn: log_in_user(conn, user_fixture())}
   end
@@ -20,8 +22,8 @@ defmodule ExNVRWeb.DeviceLiveTest do
       assert html =~ "Creating..."
     end
 
-    test "render update device page", %{conn: conn} do
-      device = device_fixture()
+    test "render update device page", %{conn: conn, tmp_dir: tmp_dir} do
+      device = device_fixture(%{settings: %{storage_address: tmp_dir}})
       {:ok, _lv, html} = live(conn, ~p"/devices/#{device.id}")
 
       assert html =~ "Update a device"
@@ -112,8 +114,11 @@ defmodule ExNVRWeb.DeviceLiveTest do
   end
 
   describe "Update a device" do
-    setup do
-      %{device: device_fixture(), file_device: device_fixture(%{}, "file")}
+    setup ctx do
+      %{
+        device: device_fixture(%{settings: %{storage_address: ctx.tmp_dir}}),
+        file_device: device_fixture(%{settings: %{storage_address: ctx.tmp_dir}}, "file")
+      }
     end
 
     test "update an IP Camera device", %{conn: conn, device: device} do

--- a/apps/ex_nvr_web/test/ex_nvr_web/live/recordings_list_live_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/live/recordings_list_live_test.exs
@@ -8,11 +8,6 @@ defmodule ExNVRWeb.RecordingListLiveTest do
   @moduletag :tmp_dir
   @moduletag :device
 
-  defp create_device_directories(device) do
-    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
-    File.mkdir_p!(ExNVR.Utils.bif_dir(device))
-  end
-
   defp refute_recording_info(lv, recording) do
     refute lv
            |> element(~s{[id="recording-#{recording.id}-link"]})
@@ -42,9 +37,8 @@ defmodule ExNVRWeb.RecordingListLiveTest do
   end
 
   describe "Recording list page" do
-    setup %{device: device} do
-      new_device = device_fixture(%{name: "Device_yxz"})
-      create_device_directories(new_device)
+    setup %{device: device, tmp_dir: tmp_dir} do
+      new_device = device_fixture(%{name: "Device_yxz", settings: %{storage_address: tmp_dir}})
 
       %{
         recordings:
@@ -154,9 +148,8 @@ defmodule ExNVRWeb.RecordingListLiveTest do
           do: refute_recording_info(lv, recording)
     end
 
-    test "Filter recordings by device with no recordings", %{conn: conn} do
-      new_device = device_fixture()
-      create_device_directories(new_device)
+    test "Filter recordings by device with no recordings", %{conn: conn, tmp_dir: tmp_dir} do
+      new_device = device_fixture(%{settings: %{storage_address: tmp_dir}})
 
       {:ok, lv, _html} =
         conn

--- a/apps/ex_nvr_web/test/ex_nvr_web/live/recordings_list_live_test.exs
+++ b/apps/ex_nvr_web/test/ex_nvr_web/live/recordings_list_live_test.exs
@@ -9,8 +9,8 @@ defmodule ExNVRWeb.RecordingListLiveTest do
   @moduletag :device
 
   defp create_device_directories(device) do
-    File.mkdir!(ExNVR.Utils.recording_dir(device.id))
-    File.mkdir!(ExNVR.Utils.bif_dir(device.id))
+    File.mkdir_p!(ExNVR.Utils.recording_dir(device))
+    File.mkdir_p!(ExNVR.Utils.bif_dir(device))
   end
 
   defp refute_recording_info(lv, recording) do

--- a/apps/ex_nvr_web/test/support/conn_case.ex
+++ b/apps/ex_nvr_web/test/support/conn_case.ex
@@ -79,8 +79,8 @@ defmodule ExNVRWeb.ConnCase do
   def maybe_create_device(tags) do
     if Map.has_key?(tags, :device) do
       device = ExNVR.DevicesFixtures.device_fixture()
-      File.mkdir!(ExNVR.Utils.recording_dir(device.id))
-      File.mkdir!(ExNVR.Utils.bif_dir(device.id))
+      File.mkdir!(ExNVR.Utils.recording_dir(device))
+      File.mkdir!(ExNVR.Utils.bif_dir(device))
       %{device: device}
     else
       %{}

--- a/apps/ex_nvr_web/test/support/conn_case.ex
+++ b/apps/ex_nvr_web/test/support/conn_case.ex
@@ -78,9 +78,9 @@ defmodule ExNVRWeb.ConnCase do
 
   def maybe_create_device(tags) do
     if Map.has_key?(tags, :device) do
-      device = ExNVR.DevicesFixtures.device_fixture()
-      File.mkdir!(ExNVR.Utils.recording_dir(device))
-      File.mkdir!(ExNVR.Utils.bif_dir(device))
+      device =
+        ExNVR.DevicesFixtures.device_fixture(%{settings: %{storage_address: tags[:tmp_dir]}})
+
       %{device: device}
     else
       %{}
@@ -89,7 +89,6 @@ defmodule ExNVRWeb.ConnCase do
 
   defp maybe_set_application_env(tags) do
     if Map.has_key?(tags, :tmp_dir) do
-      Application.put_env(:ex_nvr, :recording_directory, tags.tmp_dir)
       Application.put_env(:ex_nvr, :hls_directory, tags.tmp_dir)
     end
   end

--- a/apps/ex_nvr_web/test/test_helper.exs
+++ b/apps/ex_nvr_web/test/test_helper.exs
@@ -2,5 +2,3 @@ ExUnit.start(capture_log: true)
 Ecto.Adapters.SQL.Sandbox.mode(ExNVR.Repo, :manual)
 
 Faker.start()
-
-File.mkdir_p!(ExNVR.Utils.recording_dir())

--- a/config/config.exs
+++ b/config/config.exs
@@ -75,7 +75,7 @@ config :opentelemetry, traces_exporter: :none
 config :soap, :globals, version: "1.2"
 
 config :os_mon,
-  disk_space_check_interval: 1,
+  disk_space_check_interval: {:second, 30},
   disk_almost_full_threshold: 0.9
 
 # Import environment specific config. This must remain at the bottom

--- a/config/config.exs
+++ b/config/config.exs
@@ -74,6 +74,10 @@ config :opentelemetry, traces_exporter: :none
 
 config :soap, :globals, version: "1.2"
 
+config :os_mon,
+  disk_space_check_interval: 1,
+  disk_almost_full_threshold: 0.9
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
Add settings field to device:

- `generate_bif` - controls whether BIF are generated or not
- `storage_address` - allows the selection of the mountpoint where to store recordings.

Also in this PR, we update the folder structure where recordings are stored. Migration needs to be carried out to upgrade to a new version including this PR.

<hr />

To migrate from the current folder structure to the new one run in IEX
```elixir
ExNVR.Upgrade.upgrade("v0.6.0", mountpoint: <new-mount-point>, recording_dir: <old-recording-dir>)
```