### PR TITLE
Bundle external libs in release

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ variables needed to configure `ex_nvr` are:
 | **Env variable** | **descritpion** |
 |------------------|-----------------|
 | DATABASE_PATH    | The path where Sqlite database will be created. |
-| EXNVR_RECORDING_DIRECTORY | The directory where video footages will be stored |
 | EXNVR_HLS_DIRECTORY | The directory where hls playlists will be stored. Defaults to: `./data/hls`. <br/><br/>It is not necessary to expose this folder via volumes since the playlists are deleted each time the user stop streaming.
 | EXNVR_ADMIN_USERNAME | The username(email) of the admin user to create on first startup. Defaults to: `admin@localhost`. |
 | EXNVR_ADMIN_PASSWORD | The password of the admin user to create on first startup. Defaults to: `P@ssw0rd`. |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ variables needed to configure `ex_nvr` are:
 | **Env variable** | **descritpion** |
 |------------------|-----------------|
 | DATABASE_PATH    | The path where Sqlite database will be created. |
-| EXNVR_HLS_DIRECTORY | The directory where hls playlists will be stored. Defaults to: `./data/hls`. <br/><br/>It is not necessary to expose this folder via volumes since the playlists are deleted each time the user stop streaming.
+| EXNVR_HLS_DIRECTORY | The directory where hls playlists will be stored. Defaults to: `./hls`. <br/><br/>It is not necessary to expose this folder via volumes since the playlists are deleted each time the user stop streaming.
 | EXNVR_ADMIN_USERNAME | The username(email) of the admin user to create on first startup. Defaults to: `admin@localhost`. |
 | EXNVR_ADMIN_PASSWORD | The password of the admin user to create on first startup. Defaults to: `P@ssw0rd`. |
 | SECRET_KEY_BASE  | A 64 byte key that's used by **Pheonix** to encrypt cookies |

--- a/apps/ex_nvr/lib/ex_nvr/upgrade.ex
+++ b/apps/ex_nvr/lib/ex_nvr/upgrade.ex
@@ -19,7 +19,7 @@ defmodule ExNVR.Upgrade do
     mountpoint = Keyword.fetch!(opts, :mountpoint)
     recording_dir = Keyword.fetch!(opts, :recording_dir)
 
-    ExNVR.Repo.update_all(Device, [set: [settings: %Device.Settings{storage_address: mountpoint}]])
+    ExNVR.Repo.update_all(Device, set: [settings: %Device.Settings{storage_address: mountpoint}])
     devices = ExNVR.Repo.all(Device)
 
     Enum.each(devices, &create_device_directories/1)
@@ -59,6 +59,5 @@ defmodule ExNVR.Upgrade do
       end)
       |> Stream.run()
     end)
-
   end
 end

--- a/apps/ex_nvr/test/support/data_case.ex
+++ b/apps/ex_nvr/test/support/data_case.ex
@@ -33,7 +33,6 @@ defmodule ExNVR.DataCase do
 
   setup tags do
     if Map.has_key?(tags, :tmp_dir) do
-      Application.put_env(:ex_nvr, :recording_directory, tags.tmp_dir)
       Application.put_env(:ex_nvr, :hls_directory, tags.tmp_dir)
     end
 

--- a/apps/ex_nvr_web/lib/ex_nvr_web/live/device_live.ex
+++ b/apps/ex_nvr_web/lib/ex_nvr_web/live/device_live.ex
@@ -6,6 +6,8 @@ defmodule ExNVRWeb.DeviceLive do
   alias ExNVR.{Devices, DeviceSupervisor}
   alias ExNVR.Model.Device
 
+  @env Mix.env()
+
   def mount(%{"id" => "new"}, _session, socket) do
     changeset = Devices.change_device_creation(%Device{})
 
@@ -92,7 +94,7 @@ defmodule ExNVRWeb.DeviceLive do
   end
 
   defp get_disks_data() do
-    if Mix.env() == :test do
+    if @env == :test do
       [{"/tmp", 1_000_000, 1}]
     else
       :disksup.get_disk_data()

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -8,7 +8,6 @@ config :ex_nvr, ExNVR.Repo,
   show_sensitive_data_on_connection_error: true
 
 config :ex_nvr,
-  recording_directory: Path.expand("../data/recordings", Path.dirname(__ENV__.file)),
   hls_directory: Path.expand("../data/hls", Path.dirname(__ENV__.file)),
   run_pipelines: false
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -55,10 +55,9 @@ if config_env() == :prod do
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5")
 
   config :ex_nvr,
-    hls_directory: System.get_env("EXNVR_HLS_DIRECTORY", "./data/hls"),
+    hls_directory: System.get_env("EXNVR_HLS_DIRECTORY", "./hls"),
     admin_username: System.get_env("EXNVR_ADMIN_USERNAME", "admin@localhost"),
-    admin_password: System.get_env("EXNVR_ADMIN_PASSWORD", "P@ssw0rd"),
-    generate_bif: String.to_atom(System.get_env("EXNVR_GENERATE_BIF", "true"))
+    admin_password: System.get_env("EXNVR_ADMIN_PASSWORD", "P@ssw0rd")
 
   config :ex_nvr,
     integrated_turn_ip:

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -55,7 +55,6 @@ if config_env() == :prod do
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5")
 
   config :ex_nvr,
-    recording_directory: System.fetch_env!("EXNVR_RECORDING_DIRECTORY"),
     hls_directory: System.get_env("EXNVR_HLS_DIRECTORY", "./data/hls"),
     admin_username: System.get_env("EXNVR_ADMIN_USERNAME", "admin@localhost"),
     admin_password: System.get_env("EXNVR_ADMIN_PASSWORD", "P@ssw0rd"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,9 +13,7 @@ config :ex_nvr, ExNVR.Repo,
   pool_size: 5,
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :ex_nvr,
-  recording_directory: ".",
-  run_pipelines: false
+config :ex_nvr, run_pipelines: false
 
 # integrated turn variables
 config :ex_nvr,

--- a/docker/.env
+++ b/docker/.env
@@ -1,5 +1,4 @@
 DATABASE_PATH=/home/app/data/database/database.db
-EXNVR_RECORDING_DIRECTORY=/home/app/data/recordings
 EXNVR_ADMIN_USERNAME=admin@localhost
 EXNVR_ADMIN_PASSWORD=P@ssw0rd
 SECRET_KEY_BASE=58xo0WYYV/zY0hF4Ay453xSCUTjvXsh2j4fV8fPGDVl9Ecq58U9Vei4Vm4f486Vp

--- a/mix.exs
+++ b/mix.exs
@@ -80,7 +80,7 @@ defmodule ExNVR.Umbrella.MixProject do
     # Same thing happened when using `:tar` step, links are not copied correctly
     # which made the size of the tar ball big.
     {arch, os, abi} = get_target()
-    filename = "#{release.name}-#{release.version}-#{arch}-unknown-#{os}-#{abi}.tar.gz"
+    filename = "#{release.name}-v#{release.version}-#{arch}-unknown-#{os}-#{abi}.tar.gz"
     dest = Path.expand("../..", release.path)
 
     System.cmd("tar", [

--- a/mix.exs
+++ b/mix.exs
@@ -65,11 +65,15 @@ defmodule ExNVR.Umbrella.MixProject do
   defp copy_libs(arch, dest_dir) do
     # Tried to use `File.cp` to copy dependencies however links are not copied correctly
     # which made the size of the destination folder 3 times the orginal size.
-    src_1 = Path.join(["_build", "#{Mix.env()}", "bundlex_precompiled", "**", "lib", "*.so*"])
-    src_2 = "/usr/lib/#{arch}-linux-gnu/libsrtp2.so*"
-    src_3 = "/usr/lib/#{arch}-linux-gnu/libturbojpeg.so*"
+    libs = [
+      Path.join(["_build", "#{Mix.env()}", "bundlex_precompiled", "**", "lib", "*.so*"]),
+      "/usr/lib/#{arch}-linux-gnu/libsrtp2.so*",
+      "/usr/lib/#{arch}-linux-gnu/libturbojpeg.so*",
+      "/usr/lib/#{arch}-linux-gnu/libssl.so*",
+      "/usr/lib/#{arch}-linux-gnu/libcrypto.so*"
+    ]
 
-    System.shell("cp -P #{src_1} #{src_2} #{src_3} #{dest_dir}")
+    System.shell("cp -P #{Enum.join(libs, " ")} #{dest_dir}")
   end
 
   defp archive(release) do

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,9 @@ defmodule ExNVR.Umbrella.MixProject do
     [
       ex_nvr: [
         version: @version,
-        applications: [ex_nvr: :permanent, ex_nvr_web: :permanent]
+        applications: [ex_nvr: :permanent, ex_nvr_web: :permanent],
+        include_executables_for: [:unix],
+        steps: [:assemble, &copy_external_libs/1, &archive/1]
       ]
     ]
   end
@@ -45,5 +47,55 @@ defmodule ExNVR.Umbrella.MixProject do
       # run `mix setup` in all child apps
       setup: ["cmd mix setup"]
     ]
+  end
+
+  defp copy_external_libs(release) do
+    case get_target() do
+      {arch, "linux", "gnu"} ->
+        libs_dest = Path.join(release.path, "external_lib")
+        File.mkdir!(libs_dest)
+        copy_libs(arch, libs_dest)
+        release
+
+      _other ->
+        release
+    end
+  end
+
+  defp copy_libs(arch, dest_dir) do
+    # Tried to use `File.cp` to copy dependencies however links are not copied correctly
+    # which made the size of the destination folder 3 times the orginal size.
+    src_1 = Path.join(["_build", "#{Mix.env()}", "bundlex_precompiled", "**", "lib", "*.so*"])
+    src_2 = "/lib/#{arch}-linux-gnu/libsrtp2.so*"
+    src_3 = "/lib/#{arch}-linux-gnu/libturbojpeg.so*"
+
+    System.shell("cp -P #{src_1} #{src_2} #{src_3} #{dest_dir}")
+  end
+
+  defp archive(release) do
+    # Same thing happened when using `:tar` step, links are not copied correctly
+    # which made the size of the tar ball big.
+    {arch, os, abi} = get_target()
+    filename = "#{release.name}-#{release.version}-#{arch}-unknown-#{os}-#{abi}.tar.gz"
+    dest = Path.expand("../..", release.path)
+
+    System.cmd("tar", [
+      "-czvf",
+      Path.join(dest, filename),
+      "-C",
+      Path.expand("..", release.path),
+      "#{release.name}"
+    ])
+
+    release
+  end
+
+  defp get_target() do
+    [architecture, _vendor, os, abi] =
+      :erlang.system_info(:system_architecture)
+      |> List.to_string()
+      |> String.split("-")
+
+    {architecture, os, abi}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule ExNVR.Umbrella.MixProject do
     case get_target() do
       {arch, "linux", "gnu"} ->
         libs_dest = Path.join(release.path, "external_lib")
-        File.mkdir!(libs_dest)
+        File.mkdir_p!(libs_dest)
         copy_libs(arch, libs_dest)
         release
 

--- a/mix.exs
+++ b/mix.exs
@@ -66,8 +66,8 @@ defmodule ExNVR.Umbrella.MixProject do
     # Tried to use `File.cp` to copy dependencies however links are not copied correctly
     # which made the size of the destination folder 3 times the orginal size.
     src_1 = Path.join(["_build", "#{Mix.env()}", "bundlex_precompiled", "**", "lib", "*.so*"])
-    src_2 = "/lib/#{arch}-linux-gnu/libsrtp2.so*"
-    src_3 = "/lib/#{arch}-linux-gnu/libturbojpeg.so*"
+    src_2 = "/usr/lib/#{arch}-linux-gnu/libsrtp2.so*"
+    src_3 = "/usr/lib/#{arch}-linux-gnu/libturbojpeg.so*"
 
     System.shell("cp -P #{src_1} #{src_2} #{src_3} #{dest_dir}")
   end

--- a/rel/env.bat.eex
+++ b/rel/env.bat.eex
@@ -1,0 +1,8 @@
+@echo off
+rem Set the release to load code on demand (interactive) instead of preloading (embedded).
+rem set RELEASE_MODE=interactive
+
+rem Set the release to work across nodes.
+rem RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
+rem set RELEASE_DISTRIBUTION=name
+rem set RELEASE_NODE=<%= @release.name %>

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -20,3 +20,7 @@
 # export RELEASE_NODE=<%= @release.name %>
 
 export LD_LIBRARY_PATH=external_lib
+export DATABASE_PATH=./database/ex_nvr.db
+export EXNVR_HLS_DIRECTORY=./hls
+export SECRET_KEY_BASE=<%= Base.encode16(:crypto.strong_rand_bytes(32), case: :lower) %>
+export EXNVR_JSON_LOGGER=false

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# # Sets and enables heart (recommended only in daemon mode)
+# case $RELEASE_COMMAND in
+#   daemon*)
+#     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
+#     export HEART_COMMAND
+#     export ELIXIR_ERL_OPTIONS="-heart"
+#     ;;
+#   *)
+#     ;;
+# esac
+
+# # Set the release to load code on demand (interactive) instead of preloading (embedded).
+# export RELEASE_MODE=interactive
+
+# # Set the release to work across nodes.
+# # RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
+# export RELEASE_DISTRIBUTION=name
+# export RELEASE_NODE=<%= @release.name %>
+
+export LD_LIBRARY_PATH=external_lib

--- a/rel/overlays/run
+++ b/rel/overlays/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+./bin/ex_nvr eval "ExNVR.Release.migrate"
+./bin/ex_nvr start

--- a/rel/remote.vm.args.eex
+++ b/rel/remote.vm.args.eex
@@ -1,0 +1,8 @@
+## Customize flags given to the VM: https://www.erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -1,0 +1,8 @@
+## Customize flags given to the VM: https://www.erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10


### PR DESCRIPTION
Bundle external libs in the release after running `mix release`. The following dependencies are copied to the release:

- ffmpeg
- libsrtp2
- libturbojpeg
- libssl
- libcrypto

Currently this only works for `GNU/Linux`.