### PR TITLE
Do not crash main pipeline on write to disk issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To start it on boot
 sudo systemctl enable ex_nvr.service
 ```
 
-To delete the package, first stop the service and the use `dpkg` to delete it
+To delete the package, first stop the service and then run `dpkg` to delete it
 ```bash
 sudo systemctl stop ex_nvr.service
 sudo systemctl disable ex_nvr.service
@@ -77,7 +77,7 @@ If you want to configure some aspects of `ex_nvr`, you can set the following env
 | EXNVR_ADMIN_USERNAME | The username(email) of the admin user to create on first startup. Defaults to: `admin@localhost`. |
 | EXNVR_ADMIN_PASSWORD | The password of the admin user to create on first startup. Defaults to: `P@ssw0rd`. |
 | SECRET_KEY_BASE  | A 64 byte key that's used by **Pheonix** to encrypt cookies |
-| EXNVR_URL | The `url` to use for generating URLs and as a default value for `check_origins` of the websocket. Defaults to: `http://localhost:4000` |
+| EXNVR_URL | The `url` to use for generating URLs. The `host` is used as a default value for `check_origin` of the websocket. Defaults to: `http://localhost:4000` |
 | EXNVR_HTTP_PORT | Http `port`, defaults to: `4000` |
 | EXNVR_CORS_ALLOWED_ORIGINS | A space separated allowed origins for `CORS` requests. defaults to: `*` |
 | EXNVR_ENABLE_HTTPS | Enable `https`, default: `false` |

--- a/apps/ex_nvr/lib/ex_nvr/pipeline/output/storage/segmenter.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipeline/output/storage/segmenter.ex
@@ -93,6 +93,16 @@ defmodule ExNVR.Pipeline.Output.Storage.Segmenter do
   end
 
   @impl true
+  def handle_pad_removed(Pad.ref(:output, ref), _ctx, %{start_time: ref}) do
+    {[], init_state()}
+  end
+
+  @impl true
+  def handle_pad_removed(_pad, _ctx, state) do
+    {[], state}
+  end
+
+  @impl true
   def handle_process(:input, buffer, _ctx, %{start_time: nil} = state)
       when not Utils.keyframe(buffer) do
     # ignore, we need to start recording from a keyframe

--- a/apps/ex_nvr/lib/ex_nvr/pipeline/output/thumbnailer.ex
+++ b/apps/ex_nvr/lib/ex_nvr/pipeline/output/thumbnailer.ex
@@ -5,6 +5,8 @@ defmodule ExNVR.Pipeline.Output.Thumbnailer do
 
   use Membrane.Bin
 
+  require Membrane.Logger
+
   alias __MODULE__.{KeyFrameSelector, Sink}
   alias Membrane.{FFmpeg, H264, H265}
 
@@ -38,23 +40,25 @@ defmodule ExNVR.Pipeline.Output.Thumbnailer do
                 description: "The codec used to compress the frames"
               ]
 
+  @interval :timer.seconds(5)
+
   @impl true
   def handle_init(_ctx, options) do
-    File.mkdir_p!(options.dest)
+    state = Map.from_struct(options)
 
-    spec = [
-      bin_input()
-      |> child(:key_frame_selector, %KeyFrameSelector{interval: options.interval})
-      |> child(:decoder, get_decoder(options.encoding))
-      |> child(:scaler, %FFmpeg.SWScale.Scaler{
-        output_width: options.thumbnail_width,
-        use_shm?: true
-      })
-      |> child(:image_encoder, Turbojpeg.Filter)
-      |> child(:sink, %Sink{dest: options.dest})
-    ]
+    spec = [bin_input() |> child(:tee, Membrane.Tee.Parallel)]
 
-    {[spec: spec], %{}}
+    case check_directory(state.dest) do
+      :ok ->
+        {[spec: spec, spec: get_spec(state)], state}
+
+      {:error, reason} ->
+        Membrane.Logger.error(
+          "Could not make directory or directory not writable '#{state.dest}', error: #{inspect(reason)}"
+        )
+
+        {[start_timer: {:check_directory, @interval}], state}
+    end
   end
 
   @impl true
@@ -67,6 +71,41 @@ defmodule ExNVR.Pipeline.Output.Thumbnailer do
     {[], state}
   end
 
+  @impl true
+  def handle_tick(:check_directory, _ctx, state) do
+    case check_directory(state.dest) do
+      :ok ->
+        {[spec: get_spec(state), stop_timer: :check_directory], state}
+
+      _error ->
+        {[], state}
+    end
+  end
+
+  @impl true
+  def handle_crash_group_down(_group_name, _ctx, state) do
+    Membrane.Logger.error("crash in thumbnailer")
+    {[start_timer: {:check_directory, @interval}], state}
+  end
+
+  defp get_spec(state) do
+    {[
+       get_child(:tee)
+       |> child(:key_frame_selector, %KeyFrameSelector{interval: state.interval})
+       |> child(:decoder, get_decoder(state.encoding))
+       |> child(:scaler, %FFmpeg.SWScale.Scaler{
+         output_width: state.thumbnail_width,
+         use_shm?: true
+       })
+       |> child(:image_encoder, Turbojpeg.Filter)
+       |> child(:sink, %Sink{dest: state.dest})
+     ], group: make_ref(), crash_group_mode: :temporary}
+  end
+
   defp get_decoder(:H264), do: %H264.FFmpeg.Decoder{use_shm?: true}
   defp get_decoder(:H265), do: %H265.FFmpeg.Decoder{use_shm?: true}
+
+  defp check_directory(dest) do
+    if File.exists?(dest), do: ExNVR.Utils.writable(dest), else: File.mkdir(dest)
+  end
 end

--- a/apps/ex_nvr/lib/ex_nvr/utils.ex
+++ b/apps/ex_nvr/lib/ex_nvr/utils.ex
@@ -41,6 +41,23 @@ defmodule ExNVR.Utils do
 
   defp pad_number(number), do: String.pad_leading("#{number}", 2, "0")
 
+  @doc """
+  Check if destination exists and writable
+  """
+  @spec writable(Path.t()) :: :ok | {:error, term()}
+  def writable(dest) do
+    touch_file = Path.join(dest, ".ex_nvr_check")
+
+    case File.touch(touch_file) do
+      :ok ->
+        File.rm(touch_file)
+        :ok
+
+      error ->
+        error
+    end
+  end
+
   # Streaming & Codecs utilities
   defguard keyframe(buffer)
            when (is_map_key(buffer.metadata, :h264) and buffer.metadata.h264.key_frame?) or


### PR DESCRIPTION
If the storage address (mountpoint) where to device data are stored becomes un-writable or inaccessible, the main pipeline is crashed (losing the live view in this case) and a lot of log errors are generated.
In this PR, we fix the issue by just deleting the elements and checking the directory accessibility each 5 seconds, once it becomes accessible, the normal behaviour of the main pipeline resumes.