### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ NVR (Network Video Recorder) for Elixir using [Membrane Framework](https://githu
 
 ### Docker
 
-To get started with `ex_nvr` it's preferrable and easy to run a docker image:
+To get started with `ex_nvr` it's preferable and easy to run a docker image:
 ```bash
 docker run --rm -it -p 4000:4000 --env-file .env ghcr.io/evercam/ex_nvr:latest
 ```
@@ -84,7 +84,7 @@ sudo dpkg -P ex-nvr
 
 If you want to configure some aspects of `ex_nvr`, you can set the following environment variables:
 
-| **Env variable** | **descritpion** |
+| **Env variable** | **description** |
 |------------------|-----------------|
 | DATABASE_PATH    | The path where Sqlite database will be created. Defaults to: `/var/lib/ex_nvr/ex_nvr.db` |
 | EXNVR_HLS_DIRECTORY | The directory where hls playlists will be stored. Defaults to: `/tmp/hls`. <br/><br/>It is not necessary to expose this folder via volumes since the playlists are deleted each time the user stop streaming.
@@ -105,7 +105,7 @@ If you want to configure some aspects of `ex_nvr`, you can set the following env
 
 ### WebRTC Configuration
 
-| **Env variable** | **descritpion** |
+| **Env variable** | **description** |
 |------------------|-----------------|
 | EXTERNAL_IP | The external IP address to which attach the turn server. Defaults to: `127.0.0.1` |
 | VIRTUAL_HOST | The TURN server domain name. Defaults to: `localhost` |
@@ -131,7 +131,7 @@ A webrtc player can be embedded in web page by using `iframe`
 <iframe width="640" height="480" src="http://localhost:4000/webrtc/device_id?access_token=token" title="ex_nvr" allowfullscreen></iframe>
 ```
 
-> The `access_token` will eventually expire and must be updated to ensure the proper functionning of the embedded page. We plan to enhance this by introducing the capability to make the page public or generate non-expiring tokens with view privileges. 
+> The `access_token` will eventually expire and must be updated to ensure the proper functioning of the embedded page. We plan to enhance this by introducing the capability to make the page public or generate non-expiring tokens with view privileges. 
 
 ## Features
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -21,7 +21,7 @@ defmodule ConfigParser do
     else
       _else ->
         raise("""
-        Bad INTEGRATED_TURN_PORT_RANGE enviroment variable value. Expected "from-to", where `from` and `to` \
+        Bad INTEGRATED_TURN_PORT_RANGE environment variable value. Expected "from-to", where `from` and `to` \
         are numbers between 0 and 65535 and `from` is not bigger than `to`, got: \
         #{inspect(range)}
         """)
@@ -36,7 +36,7 @@ defmodule ConfigParser do
     else
       _var ->
         raise(
-          "Bad #{var_name} enviroment variable value. Expected valid port number, got: #{inspect(port)}"
+          "Bad #{var_name} environment variable value. Expected valid port number, got: #{inspect(port)}"
         )
     end
   end

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,7 +42,7 @@ Update `docker-compose.yml` file to use the appropriate image.
 
 If `https` is enabled and it should be, we'll need a private key and a certificate. Generating this files is out of the scope of this guide. However, there's many ways to generate this certificates, like self signed certificates (not recommended for production) or using a tool like [`let's encrypt`](https://letsencrypt.org/).
 
-In this guide, we assume the files are called `certificate.key` for the key, and `certficate.crt` for the certificate.
+In this guide, we assume the files are called `certificate.key` for the key, and `certificate.crt` for the certificate.
 
 ## Prepare volumes
 

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule ExNVR.Umbrella.MixProject do
 
   defp copy_libs(arch, dest_dir) do
     # Tried to use `File.cp` to copy dependencies however links are not copied correctly
-    # which made the size of the destination folder 3 times the orginal size.
+    # which made the size of the destination folder 3 times the original size.
     libs = [
       "/usr/lib/#{arch}-linux-gnu/libsrtp2.so*",
       "/usr/lib/#{arch}-linux-gnu/libturbojpeg.so*",


### PR DESCRIPTION
found via `codespell -S apps,docs`