### PR TITLE
update elixir to 1.17.2 from 1.15.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1.2-alpine-3.18.4 AS build
+FROM hexpm/elixir:1.17.2-erlang-27.0-alpine-3.18.7 AS build
 
 # install build dependencies
 RUN \
@@ -45,7 +45,7 @@ RUN mix deps.compile
 RUN mix do compile, release
 
 # prepare release image
-FROM alpine:3.18.5 AS app
+FROM alpine:3.18.7 AS app
 
 # install runtime dependencies
 RUN \

--- a/Dockerfile-armv7
+++ b/Dockerfile-armv7
@@ -1,4 +1,4 @@
-FROM arm32v7/elixir:1.14-otp-25-alpine AS build
+FROM arm32v7/elixir:1.17.2-otp-27-alpine AS build
 
 # install build dependencies
 RUN \
@@ -47,7 +47,7 @@ RUN cd apps/ex_nvr_web && mix assets.deploy
 RUN mix do compile, release
 
 # prepare release image
-FROM alpine:3.17.5 AS app
+FROM alpine:3.18.7 AS app
 
 # install runtime dependencies
 RUN \


### PR DESCRIPTION
Docker file updated to use Elixir version to `1.17.2` from `1.15.7`. 
Tested on local machine and Raspberry PI v4. 

This upgrade is crucial to unblock `livebook` integration.- [369](https://github.com/evercam/ex_nvr/issues/369)