### PR TITLE
fix conversion from annexb to elementary stream

### DIFF
--- a/rtsp/mix.exs
+++ b/rtsp/mix.exs
@@ -4,7 +4,7 @@ defmodule ExNvrRtsp.MixProject do
   def project do
     [
       app: :ex_nvr_rtsp,
-      version: "0.16.1",
+      version: "0.16.2",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/ui/assets/package-lock.json
+++ b/ui/assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ex_nvr",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ex_nvr",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "ISC",
       "dependencies": {
         "@jellyfish-dev/membrane-webrtc-js": "^0.6.3",

--- a/ui/assets/package.json
+++ b/ui/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ex_nvr",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/ui/lib/ex_nvr/pipeline/output/storage.ex
+++ b/ui/lib/ex_nvr/pipeline/output/storage.ex
@@ -349,7 +349,7 @@ defmodule ExNVR.Pipeline.Output.Storage do
         dts: ExMP4.Helper.timescalify(Buffer.get_dts_or_pts(last_buffer), :nanosecond, timescale),
         pts: ExMP4.Helper.timescalify(last_buffer.pts, :nanosecond, timescale),
         sync?: Utils.keyframe(last_buffer),
-        payload: convert_annexb_to_elementary_stream(last_buffer),
+        payload: convert_annexb_to_elementary_stream(last_buffer, state.track.media),
         duration: ExMP4.Helper.timescalify(duration, :nanosecond, timescale)
       })
 

--- a/ui/mix.exs
+++ b/ui/mix.exs
@@ -2,7 +2,7 @@ defmodule ExNVR.MixProject do
   use Mix.Project
 
   @app :ex_nvr
-  @version "0.16.1"
+  @version "0.16.2"
 
   def project do
     [

--- a/ui/priv/static/openapi.yaml
+++ b/ui/priv/static/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: ExNVR API
   description: Manage ExNVR via API endpoints
-  version: 0.16.1
+  version: 0.16.2
 servers:
   - url: '{protocol}://{host}:{port}'
     variables:


### PR DESCRIPTION
The conversion relies on the nalus type metadata on the buffer to delete parameter sets. Unfortunately some cameras doesn't respect the rtp spec and instead of marking each nalu with an `rtp marker` they put the maker only on the last rtp containing the last slice of the whole access unit.