### PR TITLE
giraffe: enable serial expansion hat

### DIFF
--- a/nerves_fw/config/giraffe.exs
+++ b/nerves_fw/config/giraffe.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :nerves, :firmware, fwup_conf: "giraffe/fwup.conf"

--- a/nerves_fw/config/target.exs
+++ b/nerves_fw/config/target.exs
@@ -173,4 +173,6 @@ config :nerves_time, :servers, [
 # of this file so it overrides the configuration defined above.
 # Uncomment to use target specific configurations
 
-# import_config "#{Mix.target()}.exs"
+if Mix.target() == :giraffe do
+  import_config "giraffe.exs"
+end

--- a/nerves_fw/giraffe/config.txt
+++ b/nerves_fw/giraffe/config.txt
@@ -1,0 +1,72 @@
+# Default Nerves RPi 5 config.txt
+#
+# It's possible to override this file by using a custom fwup.conf
+# configuration to pull in a replacement.
+#
+# Useful links:
+# http://rptl.io/configtxt
+# https://www.raspberrypi.org/documentation/configuration/device-tree.md
+# https://github.com/raspberrypi/documentation/blob/master/configuration/device-tree.md
+# https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README
+
+# We always use the same names. The variant is selected in fwup.conf.
+start_file=start4.elf
+fixup_file=fixup4.dat
+
+# Disable the boot rainbow
+disable_splash=1
+
+# This, along with the Raspberry Pi "x" firmware is needed for the camera
+# to work. The Raspberry Pi "x" firmware is selected via the Buildroot
+# configuration. See Target packages->Hardware handling->Firmware.
+gpu_mem=192
+
+# Enable I2C
+dtparam=i2c_arm=on
+
+# Enable audio (loads snd_bcm3825)
+dtparam=audio=on
+
+# Automatically load overlays for detected cameras
+camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
+
+# Don't have the firmware create an initial video= setting in cmdline.txt.
+# Use the kernel's default instead.
+disable_fw_kms_setup=1
+
+# Run in 64-bit mode
+arm_64bit=1
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+# Run as fast as firmware / board allows
+arm_boost=1
+
+# Comment this in or modify to enable OneWire
+# NOTE: check that the overlay that you specify is in the boot partition or
+#       this won't work.
+#dtoverlay=w1-gpio-pullup,gpiopin=4
+
+# Support USB gadget mode on the USB-C port
+dtoverlay=dwc2
+
+# The ramoops overlay works with the pstore driver to preserve crash
+# information across reboots in DRAM
+dtoverlay=ramoops
+
+# Support serial expansion hat SC16IS752
+dtoverlay=sc16is752-i2c,int_pin=27,addr=0x4d,xtal=3072000
+
+# Enable the UART (/dev/ttyAMA0)
+enable_uart=1
+
+
+

--- a/nerves_fw/giraffe/fwup.conf
+++ b/nerves_fw/giraffe/fwup.conf
@@ -1,0 +1,474 @@
+# Firmware configuration file for the Raspberry Pi 5
+
+require-fwup-version="0.15.0"  # For the trim() call
+
+include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
+
+# File resources are listed in the order that they are included in the .fw file
+# This is important, since this is the order that they're written on a firmware
+# update due to the event driven nature of the update system.
+file-resource fixup4.dat {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/fixup4x.dat"
+}
+file-resource start4.elf {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/start4x.elf"
+}
+file-resource config.txt {
+    host-path = "${NERVES_APP}/giraffe/config.txt"
+}
+file-resource cmdline.txt {
+    host-path = "${NERVES_SYSTEM}/images/cmdline.txt"
+}
+file-resource kernel8.img {
+    host-path = "${NERVES_SYSTEM}/images/Image"
+}
+file-resource bcm2712-rpi-5-b.dtb {
+    host-path = "${NERVES_SYSTEM}/images/bcm2712-rpi-5-b.dtb"
+}
+file-resource bcm2712-rpi-cm5-cm4io.dtb {
+    host-path = "${NERVES_SYSTEM}/images/bcm2712-rpi-cm5-cm4io.dtb"
+}
+file-resource bcm2712-rpi-cm5-cm5io.dtb {
+    host-path = "${NERVES_SYSTEM}/images/bcm2712-rpi-cm5-cm5io.dtb"
+}
+file-resource bcm2712-rpi-cm5l-cm4io.dtb {
+    host-path = "${NERVES_SYSTEM}/images/bcm2712-rpi-cm5l-cm4io.dtb"
+}
+file-resource bcm2712-rpi-cm5l-cm5io.dtb {
+    host-path = "${NERVES_SYSTEM}/images/bcm2712-rpi-cm5l-cm5io.dtb"
+}
+file-resource overlay_map.dtb {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/overlay_map.dtb"
+}
+file-resource bcm2712d0.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/bcm2712d0.dtbo"
+}
+file-resource rpi-ft5406.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/rpi-ft5406.dtbo"
+}
+file-resource rpi-backlight.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/rpi-backlight.dtbo"
+}
+file-resource w1-gpio-pullup.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pullup.dtbo"
+}
+file-resource miniuart-bt.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/miniuart-bt.dtbo"
+}
+file-resource vc4-kms-v3d.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-v3d.dtbo"
+}
+file-resource vc4-kms-dsi-7inch.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-dsi-7inch.dtbo"
+}
+file-resource tc358743.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/tc358743.dtbo"
+}
+file-resource dwc2.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/dwc2.dtbo"
+}
+file-resource ramoops.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/ramoops.dtb"
+}
+file-resource imx219.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx219.dtbo"
+}
+file-resource imx296.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx296.dtbo"
+}
+file-resource imx477.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx477.dtbo"
+}
+file-resource imx708.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx708.dtbo"
+}
+file-resource ov5647.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/ov5647.dtbo"
+}
+file-resource i2c-mux.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c-mux.dtbo"
+}
+file-resource i2c0-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c0-pi5.dtbo" }
+file-resource i2c1-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c1-pi5.dtbo" }
+file-resource i2c2-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c2-pi5.dtbo" }
+file-resource i2c3-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c3-pi5.dtbo" }
+file-resource vc4-kms-v3d-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-v3d-pi5.dtbo" }
+file-resource uart0-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart0-pi5.dtbo" }
+file-resource uart1-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart1-pi5.dtbo" }
+file-resource uart2-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart2-pi5.dtbo" }
+file-resource uart3-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart3-pi5.dtbo" }
+file-resource uart4-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart4-pi5.dtbo" }
+file-resource sc16is752-i2c.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/sc16is752-i2c.dtbo" }
+
+file-resource rootfs.img {
+    host-path = ${ROOTFS}
+
+    # Error out if the rootfs size exceeds the partition size
+    assert-size-lte = ${ROOTFS_A_PART_COUNT}
+}
+
+mbr mbr-a {
+    partition 0 {
+        block-offset = ${BOOT_A_PART_OFFSET}
+        block-count = ${BOOT_A_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = ${ROOTFS_A_PART_OFFSET}
+        block-count = ${ROOTFS_A_PART_COUNT}
+        type = 0x83 # Linux
+    }
+    partition 2 {
+        block-offset = ${APP_PART_OFFSET}
+        block-count = ${APP_PART_COUNT}
+        type = 0x83 # Linux
+        expand = true
+    }
+    # partition 3 is unused
+}
+
+mbr mbr-b {
+    partition 0 {
+        block-offset = ${BOOT_B_PART_OFFSET}
+        block-count = ${BOOT_B_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = ${ROOTFS_B_PART_OFFSET}
+        block-count = ${ROOTFS_B_PART_COUNT}
+        type = 0x83 # Linux
+    }
+    partition 2 {
+        block-offset = ${APP_PART_OFFSET}
+        block-count = ${APP_PART_COUNT}
+        type = 0x83 # Linux
+        expand = true
+    }
+    # partition 3 is unused
+}
+
+# Location where installed firmware information is stored.
+# While this is called "u-boot", u-boot isn't involved in this
+# setup. It just provides a convenient key/value store format.
+uboot-environment uboot-env {
+    block-offset = ${UBOOT_ENV_OFFSET}
+    block-count = ${UBOOT_ENV_COUNT}
+}
+
+# This firmware task writes everything to the destination media
+task complete {
+    # Only match if not mounted
+    require-unmounted-destination = true
+
+    on-init {
+        mbr_write(mbr-a)
+
+        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
+        fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
+
+        uboot_clearenv(uboot-env)
+
+        include("${NERVES_PROVISIONING}")
+
+        uboot_setenv(uboot-env, "nerves_fw_active", "a")
+        uboot_setenv(uboot-env, "nerves_fw_devpath", ${NERVES_FW_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "a.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "a.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "a.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "a.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "a.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
+    }
+
+    on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
+    on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
+    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
+    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
+    on-resource kernel8.img { fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img") }
+    on-resource bcm2712-rpi-5-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-5-b.dtb") }
+    on-resource bcm2712-rpi-cm5-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb") }
+    on-resource bcm2712-rpi-cm5-cm5io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm5io.dtb") }
+    on-resource bcm2712-rpi-cm5l-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb") }
+    on-resource bcm2712-rpi-cm5l-cm5io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb") }
+    on-resource overlay_map.dtb { fat_write(${BOOT_A_PART_OFFSET}, "overlays/overlay_map.dtb") }
+    on-resource bcm2712d0.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/bcm2712d0.dtbo") }
+    on-resource rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
+    on-resource rpi-backlight.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
+    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
+    on-resource vc4-kms-v3d.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
+    on-resource vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
+    on-resource tc358743.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo") }
+    on-resource dwc2.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo") }
+    on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
+    on-resource imx219.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo") }
+    on-resource imx296.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo") }
+    on-resource imx477.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo") }
+    on-resource imx708.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo") }
+    on-resource ov5647.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo") }
+    on-resource i2c-mux.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
+    on-resource i2c0-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c0-pi5.dtbo") }
+    on-resource i2c1-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c1-pi5.dtbo") }
+    on-resource i2c2-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c2-pi5.dtbo") }
+    on-resource i2c3-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c3-pi5.dtbo") }
+    on-resource vc4-kms-v3d-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d-pi5.dtbo") }
+    on-resource uart0-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart0-pi5.dtbo") }
+    on-resource uart1-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart1-pi5.dtbo") }
+    on-resource uart2-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart2-pi5.dtbo") }
+    on-resource uart3-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart3-pi5.dtbo") }
+    on-resource uart4-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart4-pi5.dtbo") }
+    on-resource sc16is752-i2c.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/sc16is752-i2c.dtbo") }
+
+    on-resource rootfs.img {
+        # write to the first rootfs partition
+        raw_write(${ROOTFS_A_PART_OFFSET})
+    }
+
+    on-finish {
+        # Clear out any old data in the B partition that might be mistaken for
+        # a file system. This is mostly to avoid confusion in humans when
+        # reprogramming SDCards with unknown contents.
+        raw_memset(${BOOT_B_PART_OFFSET}, 256, 0xff)
+        raw_memset(${ROOTFS_B_PART_OFFSET}, 256, 0xff)
+
+        # Invalidate the application data partition so that it is guaranteed to
+        # trigger the corrupt filesystem detection code on first boot and get
+        # formatted. If this isn't done and an old SDCard is reused, the
+        # application data could be in a weird state.
+        raw_memset(${APP_PART_OFFSET}, 256, 0xff)
+    }
+}
+
+task upgrade.a {
+    # This task upgrades the A partition
+    require-partition-offset(1, ${ROOTFS_B_PART_OFFSET})
+
+    # Verify the expected platform/architecture
+    require-uboot-variable(uboot-env, "b.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "b.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+
+    on-init {
+        info("Upgrading partition A")
+
+        # Clear some firmware information just in case this update gets
+        # interrupted midway. If this partition was bootable, it's not going to
+        # be soon.
+        uboot_unsetenv(uboot-env, "a.nerves_fw_version")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_platform")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_architecture")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_uuid")
+
+        # Reset the previous contents of the A boot partition
+        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
+        fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
+
+        # Indicate that the entire partition can be cleared
+        trim(${ROOTFS_A_PART_OFFSET}, ${ROOTFS_A_PART_COUNT})
+    }
+
+    # Write the new boot partition files and rootfs. The MBR still points
+    # to the B partition, so an error or power failure during this part
+    # won't hurt anything.
+    on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
+    on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
+    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
+    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
+    on-resource kernel8.img { fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img") }
+    on-resource bcm2712-rpi-5-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-5-b.dtb") }
+    on-resource bcm2712-rpi-cm5-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb") }
+    on-resource bcm2712-rpi-cm5-cm5io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm5io.dtb") }
+    on-resource bcm2712-rpi-cm5l-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb") }
+    on-resource bcm2712-rpi-cm5l-cm5io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb") }
+    on-resource overlay_map.dtb { fat_write(${BOOT_A_PART_OFFSET}, "overlays/overlay_map.dtb") }
+    on-resource bcm2712d0.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/bcm2712d0.dtbo") }
+    on-resource rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
+    on-resource rpi-backlight.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
+    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
+    on-resource vc4-kms-v3d.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
+    on-resource vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
+    on-resource tc358743.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo") }
+    on-resource dwc2.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo") }
+    on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
+    on-resource imx219.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo") }
+    on-resource imx296.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo") }
+    on-resource imx477.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo") }
+    on-resource imx708.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo") }
+    on-resource ov5647.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo") }
+    on-resource i2c-mux.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
+    on-resource i2c0-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c0-pi5.dtbo") }
+    on-resource i2c1-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c1-pi5.dtbo") }
+    on-resource i2c2-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c2-pi5.dtbo") }
+    on-resource i2c3-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c3-pi5.dtbo") }
+    on-resource vc4-kms-v3d-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d-pi5.dtbo") }
+    on-resource uart0-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart0-pi5.dtbo") }
+    on-resource uart1-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart1-pi5.dtbo") }
+    on-resource uart2-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart2-pi5.dtbo") }
+    on-resource uart3-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart3-pi5.dtbo") }
+    on-resource uart4-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart4-pi5.dtbo") }
+    on-resource sc16is752-i2c.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/sc16is752-i2c.dtbo") }
+
+    on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_B_PART_COUNT}
+        raw_write(${ROOTFS_A_PART_OFFSET})
+    }
+
+    on-finish {
+        # Update firmware metadata
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "a.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "a.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "a.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "a.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "a.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
+
+	# Switch over to boot the new firmware
+        uboot_setenv(uboot-env, "nerves_fw_active", "a")
+        mbr_write(mbr-a)
+    }
+
+    on-error {
+    }
+}
+
+task upgrade.b {
+    # This task upgrades the B partition
+    require-partition-offset(1, ${ROOTFS_A_PART_OFFSET})
+
+    # Verify the expected platform/architecture
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+
+    on-init {
+        info("Upgrading partition B")
+
+        # Clear some firmware information just in case this update gets
+        # interrupted midway.
+        uboot_unsetenv(uboot-env, "b.nerves_fw_version")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_platform")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_architecture")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_uuid")
+
+        # Reset the previous contents of the B boot partition
+        fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})
+        fat_setlabel(${BOOT_B_PART_OFFSET}, "BOOT-B")
+        fat_mkdir(${BOOT_B_PART_OFFSET}, "overlays")
+
+        trim(${ROOTFS_B_PART_OFFSET}, ${ROOTFS_B_PART_COUNT})
+    }
+
+    # Write the new boot partition files and rootfs. The MBR still points
+    # to the A partition, so an error or power failure during this part
+    # won't hurt anything.
+    on-resource config.txt { fat_write(${BOOT_B_PART_OFFSET}, "config.txt") }
+    on-resource cmdline.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
+    on-resource start4.elf { fat_write(${BOOT_B_PART_OFFSET}, "start4.elf") }
+    on-resource fixup4.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup4.dat") }
+    on-resource kernel8.img { fat_write(${BOOT_B_PART_OFFSET}, "kernel8.img") }
+    on-resource bcm2712-rpi-5-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-5-b.dtb") }
+    on-resource bcm2712-rpi-cm5-cm4io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb") }
+    on-resource bcm2712-rpi-cm5-cm5io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5-cm5io.dtb") }
+    on-resource bcm2712-rpi-cm5l-cm4io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb") }
+    on-resource bcm2712-rpi-cm5l-cm5io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb") }
+    on-resource overlay_map.dtb { fat_write(${BOOT_B_PART_OFFSET}, "overlays/overlay_map.dtb") }
+    on-resource bcm2712d0.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/bcm2712d0.dtbo") }
+    on-resource rpi-ft5406.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
+    on-resource rpi-backlight.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
+    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
+    on-resource vc4-kms-v3d.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
+    on-resource vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
+    on-resource tc358743.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/tc358743.dtbo") }
+    on-resource dwc2.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/dwc2.dtbo") }
+    on-resource ramoops.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo") }
+    on-resource imx219.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx219.dtbo") }
+    on-resource imx296.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx296.dtbo") }
+    on-resource imx477.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx477.dtbo") }
+    on-resource imx708.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx708.dtbo") }
+    on-resource ov5647.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ov5647.dtbo") }
+    on-resource i2c-mux.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
+    on-resource i2c0-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c0-pi5.dtbo") }
+    on-resource i2c1-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c1-pi5.dtbo") }
+    on-resource i2c2-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c2-pi5.dtbo") }
+    on-resource i2c3-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c3-pi5.dtbo") }
+    on-resource vc4-kms-v3d-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d-pi5.dtbo") }
+    on-resource uart0-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart0-pi5.dtbo") }
+    on-resource uart1-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart1-pi5.dtbo") }
+    on-resource uart2-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart2-pi5.dtbo") }
+    on-resource uart3-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart3-pi5.dtbo") }
+    on-resource uart4-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart4-pi5.dtbo") }
+    on-resource sc16is752-i2c.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/sc16is752-i2c.dtbo") }
+
+    on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_A_PART_COUNT}
+        raw_write(${ROOTFS_B_PART_OFFSET})
+    }
+
+    on-finish {
+        # Update firmware metadata
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "b.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "b.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "b.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "b.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "b.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "b.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "b.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "b.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "b.nerves_fw_uuid", "\${FWUP_META_UUID}")
+
+	# Switch over to boot the new firmware
+        uboot_setenv(uboot-env, "nerves_fw_active", "b")
+        mbr_write(mbr-b)
+    }
+
+    on-error {
+    }
+}
+
+task upgrade.unexpected {
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+    on-init {
+        error("Please check the media being upgraded. It doesn't look like either the A or B partitions are active.")
+    }
+}
+
+task upgrade.wrongplatform {
+    on-init {
+        error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
+    }
+}
+
+task provision {
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+    on-init {
+        include("${NERVES_PROVISIONING}")
+    }
+}
+task provision.wrongplatform {
+    on-init {
+        error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
+    }
+}

--- a/nerves_fw/lib/nerves_fw/giraffe/init.ex
+++ b/nerves_fw/lib/nerves_fw/giraffe/init.ex
@@ -22,14 +22,8 @@ defmodule ExNVR.Nerves.Giraffe.Init do
 
   @impl true
   def handle_continue(:init, state) do
-    {:ok, gpio1} = GPIO.open("GPIO16", :output)
-    {:ok, gpio2} = GPIO.open("GPIO26", :output)
-
-    GPIO.write(gpio1, 1)
-    GPIO.write(gpio2, 1)
-
-    GPIO.close(gpio1)
-    GPIO.close(gpio2)
+    :ok = GPIO.write_one("GPIO16", 1)
+    :ok = GPIO.write_one("GPIO26", 1)
 
     {:stop, :normal, state}
   end

--- a/nerves_fw/lib/nerves_fw/remote_configurer.ex
+++ b/nerves_fw/lib/nerves_fw/remote_configurer.ex
@@ -24,8 +24,8 @@ defmodule ExNVR.Nerves.RemoteConfigurer do
   @default_admin_user "admin@localhost"
   @config_completed_file "/data/.kit_config"
 
-  def start_link(remote_url) do
-    GenServer.start_link(__MODULE__, remote_url, name: __MODULE__)
+  def start_link(config) do
+    GenServer.start_link(__MODULE__, config, name: __MODULE__)
   end
 
   @impl true


### PR DESCRIPTION
- Disable spi to make GPIO 7 and 8 free
- Add device tree for `sc16is75-i2c` to support serial expansion hat in giraffe board.