### PR TITLE
Change hostname so device will by default show up as nvr.local

### DIFF
--- a/nerves_fw/config/target.exs
+++ b/nerves_fw/config/target.exs
@@ -119,7 +119,7 @@ config :mdns_lite,
   # because otherwise any of the devices may respond to nerves.local leading to
   # unpredictable behavior.
 
-  hosts: [:hostname, "nerves"],
+  hosts: [:hostname, "nvr"],
   ttl: 120,
 
   # Advertise the following services over mDNS.


### PR DESCRIPTION
As someone with a lot of nerves devices the default hostname is super helpful if it isn't `nerves`. It allows finding the new device without digging into networking.