### PR TITLE
Fwup public keys can be on NervesHub, should be enough

### DIFF
--- a/nerves_fw/config/target.exs
+++ b/nerves_fw/config/target.exs
@@ -149,10 +149,6 @@ config :nerves_hub_link,
     product_key: System.get_env("NERVES_HUB_PRODUCT_KEY", "fake_key"),
     product_secret: System.get_env("NERVES_HUB_PRODUCT_SECRET", "fake_secret")
   ],
-  fwup_public_keys: [
-    "iKuGXqQaMi4xwDRYobdGM0uO/BS4Kmpt0sFrkGGTLSE=",
-    "cu1VGLQcf81MODI7Pd/l1Zx8WtMslxM99IRGOZx/ezw="
-  ],
   health: [
     metadata: %{
       "Router Mac Address" => {ExNVR.Nerves.Health.Metadata, :router_mac_address, []},


### PR DESCRIPTION
Verify that this work for your setup before trusting it but it should if the same keys are on NervesHub/NervesCloud.