### PR TITLE
Add EXNVR_CHECK_ORIGIN to .env.sample

### DIFF
--- a/nerves_fw/.env.sample
+++ b/nerves_fw/.env.sample
@@ -15,3 +15,6 @@ export NERVES_HUB_ORG=nerves_hub_org
 # Elixir env variables
 export MIX_ENV=prod
 export MIX_TARGET=ex_nvr_rpi4
+
+# ExNVR variables
+export EXNVR_CHECK_ORIGIN=false # if you are not running on a domain


### PR DESCRIPTION
First setup people will generally be running an IP address or possibly the nvr.local hostname. The check origin is a bit of a problem there.