### PR TITLE
CI/CD: Add workflow for publishing Nerves FW on PRs on-demand

### DIFF
--- a/.github/workflows/nerves-preview.yml
+++ b/.github/workflows/nerves-preview.yml
@@ -1,0 +1,55 @@
+name: Build Preview Firmware
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build')
+    outputs:
+      version: ${{ steps.parse_command.outputs.version }}
+      target: ${{ steps.parse_command.outputs.target }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse the firmware build command
+        id: parse_command
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const scripts = require('./.github/workflows/scripts.js')
+            await scripts.parseNervesBuildCommand({ github, context, core })
+
+  build_firmware:
+    needs: prepare
+    uses: ./.github/workflows/nerves.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      target: ${{ needs.prepare.outputs.target }}
+
+  post_results:
+    needs: [prepare, build_firmware]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Comment with build result
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const scripts = require('./.github/workflows/scripts.js')
+            await scripts.handleNervesBuildResult({
+              github,
+              context,
+              version: '${{ needs.prepare.outputs.version }}',
+              target: '${{ needs.prepare.outputs.target }}',
+              result: '${{ needs.build_firmware.result }}'
+            })

--- a/.github/workflows/nerves.yml
+++ b/.github/workflows/nerves.yml
@@ -5,16 +5,40 @@ on:
     tags:
       - 'v*'
 
+  workflow_call:
+    inputs:
+      version:
+        description: 'Custom version string to use instead of the tag-based version'
+        required: false
+        type: string
+      target:
+        description: 'Specific target to build (ex_nvr_rpi4, ex_nvr_rpi5, or giraffe). If not specified, all targets will be built.'
+        required: false
+        type: string
+
+
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.targets.outputs.targets }}
+    steps:
+      - id: targets
+        run: |
+          if [ "${{ inputs.target }}" = "" ]; then
+            echo 'targets=["ex_nvr_rpi4", "ex_nvr_rpi5", "giraffe"]' >> $GITHUB_OUTPUT
+          else
+            echo 'targets=["${{ inputs.target }}"]' >> $GITHUB_OUTPUT
+          fi
   firmware:
     runs-on: ubuntu-latest
+    needs: define-matrix
     defaults:
       run:
         working-directory: ./nerves_fw
     strategy:
-      max-parallel: 1 # mix nerves_hub.firmware publish does not work on parallel uploads
       matrix:
-        target: [ex_nvr_rpi4, ex_nvr_rpi5, giraffe]
+        target: ${{ fromJSON(needs.define-matrix.outputs.targets) }}
     env:
       MIX_ENV: prod
       MIX_TARGET: ${{ matrix.target }}
@@ -44,6 +68,12 @@ jobs:
         run: echo "NERVES_FW_PLATFORM=giraffe" >> $GITHUB_ENV
         if: matrix.target == 'giraffe'
 
+      - name: Set version if provided
+        if: inputs.version != ''
+        run: |
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          echo "Using version: ${{ inputs.version }}"
+
       - name: Install dependencies
         run: | 
           sudo apt-get update && \
@@ -71,7 +101,14 @@ jobs:
         run: mix do deps.get, firmware.deps
 
       - name: Create firmware
-        run: mix firmware
+        run: |
+          if [ -n "$VERSION" ]; then
+            sed -i "s/@version \"[^\"]*\"/@version \"${VERSION}\"/" mix.exs
+            mix firmware
+            git checkout -- mix.exs
+          else
+            mix firmware
+          fi
 
       - name: Sign firmware
         run: |

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,33 @@
+name: PR Comment
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  comment_on_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Post comment with build instructions
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const scripts = require('./.github/workflows/scripts.js')
+            await scripts.postComment({ 
+                github,
+                context,
+                body: `
+                  📦 To trigger a firmware build, comment \`/build\` below.
+                  To build a specific target, comment \`/build <target>\` with on of the following targets
+                  Valid target names:
+                  - ex_nvr_rpi4
+                  - ex_nvr_rpi5
+                  - giraffe
+                `
+            })

--- a/.github/workflows/scripts.js
+++ b/.github/workflows/scripts.js
@@ -74,7 +74,7 @@ async function getPrData({ github, context }) {
 
   return {
     branch: pr.data.head.ref,
-    sha: pr.data.head.sha.substring(0, 7),
+    sha: pr.data.head.sha.substring(0, 6),
   }
 }
 
@@ -88,8 +88,9 @@ async function generateCustomVersion({ branch, sha, core }) {
     const mixExsContent = fs.readFileSync(mixExsPath, "utf8")
     const versionRegex = /@version\s+"([^"]+)"/
     const versionMatch = mixExsContent.match(versionRegex)
+    const formattedBranch = branch.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 5)
 
-    return `${versionMatch[1]}-${branch}-${sha}`
+    return `${versionMatch[1]}-${formattedBranch}-${sha}`
   } catch (error) {
     core.setFailed(`Error reading mix.exs: ${error.message}`)
     process.exit()

--- a/.github/workflows/scripts.js
+++ b/.github/workflows/scripts.js
@@ -1,0 +1,117 @@
+const fs = require("fs")
+const path = require("path")
+
+module.exports = {
+  postComment,
+  parseNervesBuildCommand,
+  handleNervesBuildResult,
+}
+
+async function parseNervesBuildCommand({ github, context, core }) {
+  const target = await parseBuildTarget({ github, context, core })
+  const prData = await getPrData({ github, context })
+  const version = await generateCustomVersion(prData, core)
+
+  core.setOutput("target", target)
+  core.setOutput("version", version)
+
+  await postComment({
+    github,
+    context,
+    body: `
+      🛠️ Starting preview build for version: **${version}** for target **${
+      formatTarget(target)
+    }**
+    This may take up to 15 minutes. You can check the progress on the [Github Actions page](https://github.com/evercam/ex_nvr/actions) 
+    `,
+  })
+}
+
+async function handleNervesBuildResult({ github, context, version, target, result }) {
+  let body = ""
+  if (result === "success") {
+    body = `
+      ✅ Build succeeded!
+      Version: **${version}** for target: **${formatTarget(target)}** can be found on [NervesHub](https://manage.nervescloud.com/).
+    `
+  } else {
+    body = `
+      ❌ Build failed for version: **${version}**, target: **${formatTarget(target)}**
+      Check the logs for more information.
+    `
+  }
+
+  await postComment({ github, context, body })
+}
+
+async function parseBuildTarget({ github, context, core }) {
+  const comment = context.payload.comment.body
+  const target = comment.match(/^\/build\s+([a-z0-9_]+)/)?.[1]
+  const validTargets = ["ex_nvr_rpi4", "ex_nvr_rpi5", "giraffe"]
+
+  if (target && !validTargets.includes(target)) {
+    await postComment({
+      github,
+      context,
+      body: `
+        ❌ Error: Invalid target **${target}** specified.
+        Please try again with one of the following targets, or no target at all:
+        ${validTargets.map((t) => `- ${t}`).join("\n")}
+      `,
+    })
+
+    core.setFailed(`Invalid build target: ${target}`)
+    process.exit()
+    return
+  }
+
+  return target
+}
+
+async function getPrData({ github, context }) {
+  const prUrl = context.payload.issue.pull_request.url
+  const pr = await github.request(`GET ${prUrl}`)
+
+  return {
+    branch: pr.data.head.ref,
+    sha: pr.data.head.sha.substring(0, 7),
+  }
+}
+
+async function generateCustomVersion({ branch, sha, core }) {
+  try {
+    const mixExsPath = path.join(
+      process.env.GITHUB_WORKSPACE,
+      "nerves_fw",
+      "mix.exs"
+    )
+    const mixExsContent = fs.readFileSync(mixExsPath, "utf8")
+    const versionRegex = /@version\s+"([^"]+)"/
+    const versionMatch = mixExsContent.match(versionRegex)
+
+    return `${versionMatch[1]}-${branch}-${sha}`
+  } catch (error) {
+    core.setFailed(`Error reading mix.exs: ${error.message}`)
+    process.exit()
+  }
+}
+
+async function postComment({ github, context, body }) {
+  const { owner, repo } = context.repo
+  const { number } = context.issue || context.payload.pull_request
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: number,
+    body: dedent(body),
+  })
+}
+
+function formatTarget(target = "") {
+  return target?.trim()?.length ? target : "all"
+}
+
+function dedent (str = "") {
+  return str.split('\n').map(l => l.trim()).join('\n')
+}


### PR DESCRIPTION
## On-demand Firmware Builds for Pull Requests

This PR adds the ability to trigger Nerves firmware builds directly from a PR comments, making it easier to test changes without merging to master or manually publishing a version.

## Workflow
- Comment on new PRs with build instructions
- Supports building specific targets via `/build <target>` command
- Supports building all targets with a simple `/build` command
- Uses the current version number with branch and commit hash for preview builds (e.g.: `0.18.0-my-branch-abcd64` )
- Posts build status updates as comments
- Re-uses the existing Nerves build workflow
