### PR TITLE
Add power and battery low level monitor

### DIFF
--- a/nerves_fw/config/host.exs
+++ b/nerves_fw/config/host.exs
@@ -19,3 +19,5 @@ config :nerves_runtime,
        "a.nerves_fw_platform" => "host",
        "a.nerves_fw_version" => "0.0.0"
      }}
+
+config :circuits_gpio, default_backend: {Circuits.GPIO.CDev, test: true}

--- a/nerves_fw/config/host.exs
+++ b/nerves_fw/config/host.exs
@@ -21,3 +21,7 @@ config :nerves_runtime,
      }}
 
 config :circuits_gpio, default_backend: {Circuits.GPIO.CDev, test: true}
+
+if Mix.env() == :test do
+  import_config "test.exs"
+end

--- a/nerves_fw/config/test.exs
+++ b/nerves_fw/config/test.exs
@@ -1,0 +1,29 @@
+import Config
+
+# Only in tests, remove the complexity from the password hashing algorithm
+config :bcrypt_elixir, :log_rounds, 1
+
+config :ex_nvr, env: :test
+
+config :ex_nvr, ExNVR.Repo,
+  database: Path.expand("../ex_nvr_test.db", Path.dirname(__ENV__.file)),
+  pool_size: 5,
+  pool: Ecto.Adapters.SQL.Sandbox
+
+config :ex_nvr, ExNVRWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4002],
+  secret_key_base: "v98YSVCUiOPDgBqTeAgebEm5zT1KY+FS4rtFe9BVzFzeiK9Gu8m7JxGgUCnIcPj/",
+  server: false
+
+config :logger, level: :warning
+
+# In test we don't send emails.
+config :ex_nvr, ExNVR.Mailer, adapter: Swoosh.Adapters.Test
+
+# Disable swoosh api client as it is only required for production adapters.
+config :swoosh, :api_client, false
+
+# Initialize plugs at runtime for faster test compilation
+config :phoenix, :plug_init_mode, :runtime
+
+config :ex_nvr, ExNVRWeb.PromEx, disabled: true

--- a/nerves_fw/lib/nerves_fw/application.ex
+++ b/nerves_fw/lib/nerves_fw/application.ex
@@ -27,7 +27,9 @@ defmodule ExNVR.Nerves.Application do
     [{ExNVR.Nerves.Giraffe.Init, []}] ++ common_config()
   end
 
-  def children(_target), do: common_config()
+  def children(_target) do
+    [{ExNVR.Nerves.Monitoring.Power, []}] ++ common_config()
+  end
 
   def target() do
     Application.get_env(:ex_nvr_fw, :target)

--- a/nerves_fw/lib/nerves_fw/application.ex
+++ b/nerves_fw/lib/nerves_fw/application.ex
@@ -28,7 +28,8 @@ defmodule ExNVR.Nerves.Application do
   end
 
   def children(_target) do
-    [{ExNVR.Nerves.Monitoring.Power, []}] ++ common_config()
+    DynamicSupervisor.start_child(ExNVR.Hardware.Supervisor, {ExNVR.Nerves.Hardware.Power, []})
+    common_config()
   end
 
   def target() do
@@ -45,7 +46,7 @@ defmodule ExNVR.Nerves.Application do
   end
 
   defp common_config() do
-    DynamicSupervisor.start_child(ExNVR.Hardware.Supervisor, {ExNVR.Nerves.Monitoring.RUT, []})
+    DynamicSupervisor.start_child(ExNVR.Hardware.Supervisor, {ExNVR.Nerves.Hardware.RUT, []})
 
     [
       {ExNVR.Nerves.Netbird, []},

--- a/nerves_fw/lib/nerves_fw/hardware/power.ex
+++ b/nerves_fw/lib/nerves_fw/hardware/power.ex
@@ -1,4 +1,4 @@
-defmodule ExNVR.Nerves.Monitoring.Power do
+defmodule ExNVR.Nerves.Hardware.Power do
   @moduledoc """
   Monitor AC and battery alarms.
 

--- a/nerves_fw/lib/nerves_fw/hardware/rut.ex
+++ b/nerves_fw/lib/nerves_fw/hardware/rut.ex
@@ -1,4 +1,4 @@
-defmodule ExNVR.Nerves.Monitoring.RUT do
+defmodule ExNVR.Nerves.Hardware.RUT do
   @moduledoc """
   Get basic data from Teltonika routers.
 

--- a/nerves_fw/lib/nerves_fw/health/metadata.ex
+++ b/nerves_fw/lib/nerves_fw/health/metadata.ex
@@ -1,7 +1,7 @@
 defmodule ExNVR.Nerves.Health.Metadata do
   @moduledoc false
 
-  alias ExNVR.Nerves.Monitoring.RUT
+  alias ExNVR.Nerves.Hardware.RUT
 
   @spec router_serial_number() :: String.t() | nil
   def router_serial_number(), do: router_state()[:serial_number]

--- a/nerves_fw/lib/nerves_fw/monitoring/power.ex
+++ b/nerves_fw/lib/nerves_fw/monitoring/power.ex
@@ -1,0 +1,95 @@
+defmodule ExNVR.Nerves.Monitoring.Power do
+  @moduledoc """
+  Monitor AC and battery alarms.
+
+  We'll use the following GPIO pins to monitor the power supply:
+    * GPIO16 (input) - `1` low battery level
+    * GPIO23 (input) - `0` AC failure.
+  """
+  require Logger
+
+  use GenServer
+
+  def start_link(options) do
+    GenServer.start_link(__MODULE__, options, name: __MODULE__)
+  end
+
+  def state(pid \\ __MODULE__) do
+    GenServer.call(pid, :state)
+  end
+
+  @impl true
+  def init(options) do
+    ac_pin = Keyword.get(options, :ac_pin, "GPIO23")
+    bat_pin = Keyword.get(options, :battery_pin, "GPIO16")
+
+    {:ok, ac_gpio} = Circuits.GPIO.open(ac_pin, :input)
+    {:ok, bat_gpio} = Circuits.GPIO.open(bat_pin, :input)
+
+    :ok = Circuits.GPIO.set_pull_mode(bat_gpio, :pulldown)
+    :ok = Circuits.GPIO.set_pull_mode(ac_gpio, :pulldown)
+
+    # Set up event handlers
+    :ok = Circuits.GPIO.set_interrupts(bat_gpio, :both)
+    :ok = Circuits.GPIO.set_interrupts(ac_gpio, :both)
+
+    state = %{
+      ac_pin: ac_pin,
+      bat_pin: bat_pin,
+      ac_gpio: ac_gpio,
+      bat_gpio: bat_gpio,
+      ac_timer: nil,
+      bat_timer: nil,
+      ac_ok?: Circuits.GPIO.read(ac_gpio),
+      low_battery?: Circuits.GPIO.read(bat_gpio)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:state, _from, state) do
+    {:reply, Map.take(state, [:ac_ok?, :low_battery?]), state}
+  end
+
+  @impl true
+  def handle_info({:circuits_gpio, pin, _timestamp, value}, state) do
+    {timer_field, field} =
+      case state do
+        %{ac_pin: ^pin} -> {:ac_timer, :ac_ok?}
+        %{bat_pin: ^pin} -> {:bat_timer, :low_battery?}
+      end
+
+    :timer.cancel(state[timer_field])
+    {:ok, ref} = :timer.send_after(to_timeout(second: 1), {:update, field, value})
+    {:noreply, Map.put(state, timer_field, ref)}
+  end
+
+  @impl true
+  def handle_info({:update, :ac_ok?, value}, %{ac_ok?: value} = state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:update, :low_battery?, value}, %{low_battery?: value} = state),
+    do: {:noreply, state}
+
+  @impl true
+  def handle_info({:update, key, value}, state) do
+    state = Map.put(state, key, value)
+    event = %{type: event_name(key), metadata: %{state: value}}
+
+    with {:error, changeset} <- ExNVR.Events.create_event(event) do
+      Logger.error("Failed to save event: #{inspect(changeset)}")
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(message, state) do
+    Logger.warning("Received unexpected message: #{inspect(message)}")
+    {:noreply, state}
+  end
+
+  defp event_name(:ac_ok?), do: "power"
+  defp event_name(:low_battery?), do: "low-battery"
+end

--- a/nerves_fw/lib/nerves_fw/system_status.ex
+++ b/nerves_fw/lib/nerves_fw/system_status.ex
@@ -28,7 +28,7 @@ defmodule ExNVR.Nerves.SystemStatus do
           evercam_id
       end
 
-    rut_data = ExNVR.Nerves.Monitoring.RUT.state()
+    rut_data = ExNVR.Nerves.Hardware.RUT.state()
 
     netbird_data =
       case ExNVR.Nerves.Netbird.status() do

--- a/nerves_fw/mix.exs
+++ b/nerves_fw/mix.exs
@@ -12,6 +12,7 @@ defmodule NervesFw.MixProject do
       elixir: "~> 1.17",
       archives: [nerves_bootstrap: "~> 1.13"],
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       aliases: aliases(),
       releases: [{@app, release()}],
@@ -82,4 +83,7 @@ defmodule NervesFw.MixProject do
   defp aliases do
     []
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/nerves_fw/test/monitoring/power_test.exs
+++ b/nerves_fw/test/monitoring/power_test.exs
@@ -1,0 +1,33 @@
+defmodule ExNVR.Nerves.Monitoring.PowerTest do
+  use ExUnit.Case, async: true
+
+  alias ExNVR.Nerves.Monitoring.Power
+
+  test "Power state" do
+    # Power pins (3.3v)
+    assert {:ok, ac_power} = Circuits.GPIO.open({"gpiochip0", 0}, :output)
+    assert {:ok, bat_power} = Circuits.GPIO.open({"gpiochip0", 4}, :output)
+
+    Circuits.GPIO.write(ac_power, 1)
+    Circuits.GPIO.write(bat_power, 0)
+
+    assert {:ok, pid} = Power.start_link(ac_pin: {"gpiochip0", 1}, battery_pin: {"gpiochip0", 5})
+    assert %{ac_ok?: 1, low_battery?: 0} = Power.state(pid)
+
+    # Simulate switch bouncing
+    ac_series = [1, 1, 0, 1, 0, 0, 0, 0]
+    bat_series = [0, 0, 0, 1, 0, 1, 1, 1]
+
+    Enum.each(ac_series, &Circuits.GPIO.write(ac_power, &1))
+    Enum.each(bat_series, &Circuits.GPIO.write(bat_power, &1))
+
+    Process.sleep(to_timeout(second: 2))
+
+    assert %{ac_ok?: 0, low_battery?: 1} = Power.state(pid)
+    assert {:ok, {[event], _flop}} = ExNVR.Events.list_events(%{type: "power"})
+    assert %{"state" => 0} = event.metadata
+
+    assert {:ok, {[event], _flop}} = ExNVR.Events.list_events(%{type: "low-battery"})
+    assert %{"state" => 1} = event.metadata
+  end
+end

--- a/nerves_fw/test/monitoring/power_test.exs
+++ b/nerves_fw/test/monitoring/power_test.exs
@@ -1,5 +1,5 @@
 defmodule ExNVR.Nerves.Monitoring.PowerTest do
-  use ExUnit.Case, async: true
+  use ExNVR.DataCase, async: false
 
   alias ExNVR.Nerves.Monitoring.Power
 
@@ -24,10 +24,11 @@ defmodule ExNVR.Nerves.Monitoring.PowerTest do
     Process.sleep(to_timeout(second: 2))
 
     assert %{ac_ok?: 0, low_battery?: 1} = Power.state(pid)
-    assert {:ok, {[event], _flop}} = ExNVR.Events.list_events(%{type: "power"})
+
+    assert {:ok, {[event], _flop}} = ExNVR.Events.list_events(%Flop{filters: Flop.Filter.new(type: "power")})
     assert %{"state" => 0} = event.metadata
 
-    assert {:ok, {[event], _flop}} = ExNVR.Events.list_events(%{type: "low-battery"})
+    assert {:ok, {[event], _flop}} = ExNVR.Events.list_events(%Flop{filters: Flop.Filter.new(type: "low-battery")})
     assert %{"state" => 1} = event.metadata
   end
 end

--- a/nerves_fw/test/monitoring/power_test.exs
+++ b/nerves_fw/test/monitoring/power_test.exs
@@ -1,7 +1,7 @@
 defmodule ExNVR.Nerves.Monitoring.PowerTest do
   use ExNVR.DataCase, async: false
 
-  alias ExNVR.Nerves.Monitoring.Power
+  alias ExNVR.Nerves.Hardware.Power
 
   test "Power state" do
     # Power pins (3.3v)
@@ -25,10 +25,14 @@ defmodule ExNVR.Nerves.Monitoring.PowerTest do
 
     assert %{ac_ok?: 0, low_battery?: 1} = Power.state(pid)
 
-    assert {:ok, {[event], _flop}} = ExNVR.Events.list_events(%Flop{filters: Flop.Filter.new(type: "power")})
+    assert {:ok, {[event], _flop}} =
+             ExNVR.Events.list_events(%Flop{filters: Flop.Filter.new(type: "power")})
+
     assert %{"state" => 0} = event.metadata
 
-    assert {:ok, {[event], _flop}} = ExNVR.Events.list_events(%Flop{filters: Flop.Filter.new(type: "low-battery")})
+    assert {:ok, {[event], _flop}} =
+             ExNVR.Events.list_events(%Flop{filters: Flop.Filter.new(type: "low-battery")})
+
     assert %{"state" => 1} = event.metadata
   end
 end

--- a/nerves_fw/test/support/data_case.ex
+++ b/nerves_fw/test/support/data_case.ex
@@ -1,0 +1,58 @@
+defmodule ExNVR.DataCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  access to the application's data layer.
+
+  You may define functions here to be used as helpers in
+  your tests.
+
+  Finally, if the test case interacts with the database,
+  we enable the SQL sandbox, so changes done to the database
+  are reverted at the end of every test. If you are using
+  PostgreSQL, you can even run database tests asynchronously
+  by setting `use ExNVR.DataCase, async: true`, although
+  this option is not recommended for other databases.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias ExNVR.Repo
+
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+      import ExNVR.DataCase
+    end
+  end
+
+  setup tags do
+    ExNVR.DataCase.setup_sandbox(tags)
+    :ok
+  end
+
+  @doc """
+  Sets up the sandbox based on the test tags.
+  """
+  def setup_sandbox(tags) do
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(ExNVR.Repo, shared: not tags[:async])
+    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+  end
+
+  @doc """
+  A helper that transforms changeset errors into a map of messages.
+
+      assert {:error, changeset} = Accounts.create_user(%{password: "short"})
+      assert "password is too short" in errors_on(changeset).password
+      assert %{password: ["password is too short"]} = errors_on(changeset)
+
+  """
+  def errors_on(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+end

--- a/ui/lib/ex_nvr/events.ex
+++ b/ui/lib/ex_nvr/events.ex
@@ -42,6 +42,11 @@ defmodule ExNVR.Events do
   end
 
   @spec list_events(map()) :: flop_result()
+  def list_events(%Flop{} = flop) do
+    Event |> preload([:device]) |> ExNVR.Flop.validate_and_run(flop)
+  end
+
+  @spec list_events(map()) :: flop_result()
   def list_events(params) do
     Event
     |> preload([:device])


### PR DESCRIPTION
Relates to #625 
We monitor GPIO pins for AC failures and low battery. The events are stored in database and available in `Generic Events` tab.