### PR TITLE
CI/CD: Set git SHA explicitely in nerves-preview + Add optional version name input

### DIFF
--- a/.github/workflows/nerves-preview.yml
+++ b/.github/workflows/nerves-preview.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       version: ${{ steps.parse_command.outputs.version }}
       target: ${{ steps.parse_command.outputs.target }}
+      git_sha: ${{ steps.parse_command.outputs.git_sha }}
     steps:
       - uses: actions/checkout@v4
       - name: Parse the firmware build command
@@ -25,7 +26,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const scripts = require('./.github/workflows/scripts.js')
-            await scripts.parseNervesBuildCommand({ github, context, core })
+            await scripts.handleNervesBuildCommand({ github, context, core })
 
   build_firmware:
     needs: prepare
@@ -34,6 +35,7 @@ jobs:
     with:
       version: ${{ needs.prepare.outputs.version }}
       target: ${{ needs.prepare.outputs.target }}
+      git_sha: ${{ needs.prepare.outputs.git_sha }}
 
   post_results:
     needs: [prepare, build_firmware]

--- a/.github/workflows/nerves.yml
+++ b/.github/workflows/nerves.yml
@@ -15,6 +15,11 @@ on:
         description: 'Specific target to build (ex_nvr_rpi4, ex_nvr_rpi5, or giraffe). If not specified, all targets will be built.'
         required: false
         type: string
+      git_sha:
+        description: 'Target git ref for @actions/checkout. (defaults to "master")'
+        default: 'master'
+        required: false
+        type: string
 
 
 jobs:
@@ -58,6 +63,8 @@ jobs:
       EXNVR_REMOTE_SERVER_TOKEN: ${{ secrets.EXNVR_REMOTE_SERVER_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git_sha }}
 
       - uses: erlef/setup-beam@v1.18
         with:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -29,5 +29,12 @@ jobs:
                   - ex_nvr_rpi4
                   - ex_nvr_rpi5
                   - giraffe
+                  
+                  You can also specify a custom version: \`/build <target> version=<version>\`
+                  Examples: 
+                  \`/build version=1.0.0-test\`
+                  \`/build ex_nvr_rpi5 version=1.0.0-test.123\`
+            
+                  If no version is specified, one will be generated automatically.
                 `
             })


### PR DESCRIPTION
## Description
The current version of the `nerves-preview`  workflow has a major flaw (noted by @gBillal ): It always builds and publishes the `master` branch of ExNVR, which defeats the purpose of the workflow.

After investigation, the root cause is the Github workflow trigger: `issue_comment` always runs on the main branch of the repo (as a security measure). [^1]

**Changes**
This PR fixes the issue by making the workflow:
1- Set an additional output `git_sha` during the `nerves-preview.prepare` phase, which was previously fetched from the Github API.
2- Pass `git_sha` to the `nerves` reusable workflow as an input (defaults to `master`)
3- Use it  in the `actions/checkout` step

**Other changes**
Add an optional version input in the command, to manually specify a version.
e.g.: `/build version=<custom version name>`

## Important note
Testing the workflow in this PR won't work, because of the same Github security restriction mentioned above.
It has to be merged into `master` first. [^1]

For validation, I have the same version of the workflow available on this fork https://github.com/halimb/ex_nvr

[^1]: 
    See: Issue_comment restricted to master: https://github.com/orgs/community/discussions/59389
    See: New workflows must be merged: https://github.com/orgs/community/discussions/25746
