### PR TITLE
Nerves: Remove deprecated process ExNVR.Nerves.Hardware.RUT

### DIFF
--- a/nerves_fw/lib/nerves_fw/application.ex
+++ b/nerves_fw/lib/nerves_fw/application.ex
@@ -46,8 +46,6 @@ defmodule ExNVR.Nerves.Application do
   end
 
   defp common_config() do
-    DynamicSupervisor.start_child(ExNVR.Hardware.Supervisor, {ExNVR.Nerves.Hardware.RUT, []})
-
     [
       {ExNVR.Nerves.Netbird, []},
       {ExNVR.Nerves.DiskMounter, []},


### PR DESCRIPTION
## Description
The  ExNVR.Nerves.Hardware.RUT process was removed in https://github.com/evercam/ex_nvr/pull/666 , but ExNVR.Nerves.Application.start/2 was still trying to start it, causing an error:

```
{%ArgumentError{
   message: "The module ExNVR.Nerves.Hardware.RUT was given as a child to a supervisor but it does not exist"
 }
```

This PR fixes it by removing the call.