### PR TITLE
Fix get serial number of usb hdd using smartctl

### DIFF
--- a/nerves_fw/lib/nerves_fw/application.ex
+++ b/nerves_fw/lib/nerves_fw/application.ex
@@ -53,10 +53,10 @@ defmodule ExNVR.Nerves.Application do
       {ExNVR.Nerves.GrafanaAgent, grafana_agent_config()},
       {MuonTrap.Daemon, ["nginx", [], [stderr_to_stdout: true, log_output: :info]]},
       {ExNVR.Nerves.RemoteConfigurer, Application.get_env(:ex_nvr_fw, :remote_configurer)},
-      {ExNVR.Nerves.SystemStatus, []},
       {ExNVR.Nerves.Monitoring.PowerSchedule, []},
       {ExNVR.Nerves.Monitoring.UPS, []},
-      {ExNVR.Nerves.RUT.Auth, []}
+      {ExNVR.Nerves.RUT.Auth, []},
+      {ExNVR.Nerves.SystemStatus, []}
     ]
   end
 end

--- a/nerves_fw/lib/nerves_fw/rut/auth.ex
+++ b/nerves_fw/lib/nerves_fw/rut/auth.ex
@@ -106,7 +106,7 @@ defmodule ExNVR.Nerves.RUT.Auth do
     url = base_url <> @login_path
 
     case Req.post(url, json: %{username: username, password: password}) do
-      {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+      {:ok, %Req.Response{status: 200, body: %{"data" => data}}} when is_map_key(data, "expires") ->
         req = Req.new(base_url: base_url <> "/api", auth: {:bearer, data["token"]})
         {:ok, req, data["expires"]}
 


### PR DESCRIPTION
Some usb bridges are not known by `smartctl` and we cannot get serial number. Using `-d sat` may fix the issue for some of them.

In this PR too: fix RUT authentication by returning error if the a router is using legacy API instead of raising by trying to use expires field which is `nil`.