### PR TITLE
Generic events: Use the local URL in the copyable code blocks

### DIFF
--- a/nerves_fw/lib/nerves_fw/system_status.ex
+++ b/nerves_fw/lib/nerves_fw/system_status.ex
@@ -23,6 +23,7 @@ defmodule ExNVR.Nerves.SystemStatus do
   @impl true
   def handle_info(:collect_system_metrics, state) do
     :ok = ExNVR.SystemStatus.set(:hostname, hostname())
+    :ok = ExNVR.SystemStatus.set(:local_ip, local_ip())
     :ok = ExNVR.SystemStatus.set(:router, rut_data())
     :ok = ExNVR.SystemStatus.set(:netbird, netbird())
     :ok = ExNVR.SystemStatus.set(:nerves, true)
@@ -43,6 +44,18 @@ defmodule ExNVR.Nerves.SystemStatus do
       "" -> :inet.gethostname() |> elem(1) |> List.to_string()
       evercam_id -> evercam_id
     end
+  end
+
+  def local_ip do
+    VintageNet.get(["interface", "eth0", "addresses"])
+    |> Enum.find_value(nil, fn
+      %{family: :inet, address: addr} ->
+        addr
+        |> :inet.ntoa()
+        |> to_string()
+      _ ->
+        nil
+    end)
   end
 
   defp netbird do

--- a/ui/lib/ex_nvr_web/endpoint.ex
+++ b/ui/lib/ex_nvr_web/endpoint.ex
@@ -72,4 +72,13 @@ defmodule ExNVRWeb.Endpoint do
   plug Plug.Head
   plug Plug.Session, @session_options
   plug ExNVRWeb.Router
+
+  def local_url do
+    url = Application.get_env(:ex_nvr, __MODULE__, []) |> Keyword.get(:url, [])
+    scheme = Keyword.get(url, :scheme, "http")
+    port = Keyword.get(url, :port, 4000)
+    host = ExNVR.SystemStatus.get(:local_ip) || Keyword.get(url, :host, "localhost")
+
+    "#{scheme}://#{host}:#{port}"
+  end
 end

--- a/ui/lib/ex_nvr_web/live/generic_events/webhook_config.ex
+++ b/ui/lib/ex_nvr_web/live/generic_events/webhook_config.ex
@@ -218,7 +218,7 @@ defmodule ExNVRWeb.GenericEventsLive.WebhookConfig do
   end
 
   defp endpoint_url(assigns, copyable \\ false) do
-    base_url = "#{ExNVRWeb.Endpoint.url()}/api/devices/"
+    base_url = "#{ExNVRWeb.Endpoint.local_url()}/api/devices/"
 
     device = assigns.device_id || ":device_id"
     event = assigns.type || ":type"

--- a/ui/test/ex_nvr_web/live/generic_events_live_test.exs
+++ b/ui/test/ex_nvr_web/live/generic_events_live_test.exs
@@ -178,7 +178,7 @@ defmodule ExNVRWeb.GenericEventsLiveTest do
         |> render_change()
 
       expected_url =
-        "#{ExNVRWeb.Endpoint.url()}/api/devices/#{device.id}/events?type=#{type}"
+        "#{ExNVRWeb.Endpoint.local_url()}/api/devices/#{device.id}/events?type=#{type}"
 
       assert updated =~ expected_url
     end


### PR DESCRIPTION
Fixes https://github.com/evercam/ex_nvr/issues/754
Related to https://github.com/evercam/evercam-frontend/issues/11446