### PR TITLE
Add disk serial field to run

### DIFF
--- a/ui/lib/ex_nvr/disk.ex
+++ b/ui/lib/ex_nvr/disk.ex
@@ -109,6 +109,16 @@ defmodule ExNVR.Disk do
 
   def has_filesystem?(%Part{} = part), do: not is_nil(part.fs)
 
+  @spec has_mountpoint?(t() | Part.t(), String.t()) :: boolean()
+  def has_mountpoint?(%__MODULE__{fs: %FS{mountpoint: mountpoint}}, mountpoint), do: true
+  def has_mountpoint?(%Part{fs: %FS{mountpoint: mountpoint}}, mountpoint), do: true
+
+  def has_mountpoint?(%{parts: parts}, mountpoint) when is_list(parts) do
+    Enum.any?(parts, &has_mountpoint?(&1, mountpoint))
+  end
+
+  def has_mountpoint?(_, _), do: false
+
   defp list_unix_drives(opts) do
     # By default retrieve disks with major version of 8 and 259
     major_numbers = Keyword.get(opts, :major_number, [8, 259])

--- a/ui/lib/ex_nvr/model/run.ex
+++ b/ui/lib/ex_nvr/model/run.ex
@@ -16,7 +16,8 @@ defmodule ExNVR.Model.Run do
           start_date: DateTime.t() | nil,
           end_date: DateTime.t() | nil,
           active: boolean(),
-          device_id: binary() | nil
+          device_id: binary() | nil,
+          disk_serial: String.t() | nil
         }
 
   @foreign_key_type :binary_id
@@ -25,6 +26,7 @@ defmodule ExNVR.Model.Run do
     field :end_date, :utc_datetime_usec
     field :active, :boolean, default: false
     field :stream, Ecto.Enum, values: [:high, :low], default: :high
+    field :disk_serial, :string
 
     belongs_to :device, ExNVR.Model.Device
   end

--- a/ui/lib/ex_nvr/pipeline/output/storage.ex
+++ b/ui/lib/ex_nvr/pipeline/output/storage.ex
@@ -384,7 +384,8 @@ defmodule ExNVR.Pipeline.Output.Storage do
       end_date: Segment.end_date(segment) |> Time.to_datetime(),
       device_id: state.device.id,
       stream: state.stream,
-      active: not end_run?
+      active: not end_run?,
+      disk_serial: get_disk_serial(state.device.storage_config.address)
     }
 
     %{state | run: run}
@@ -441,5 +442,17 @@ defmodule ExNVR.Pipeline.Output.Storage do
       Segment end date: #{Segment.end_date(segment) |> Time.to_datetime()}
       Current date time: #{Time.to_datetime(segment.wallclock_end_date)}
     """)
+  end
+
+  defp get_disk_serial(mountpoint) do
+    case ExNVR.Disk.list_drives() do
+      {:ok, drives} ->
+        drives
+        |> Enum.find(%{serial: nil}, &ExNVR.Disk.has_mountpoint?(&1, mountpoint))
+        |> Map.get(:serial)
+
+      _error ->
+        nil
+    end
   end
 end

--- a/ui/priv/repo/migrations/20250729105500_add_disk_serial_to_run.exs
+++ b/ui/priv/repo/migrations/20250729105500_add_disk_serial_to_run.exs
@@ -2,7 +2,7 @@ defmodule ExNVR.Repo.Migrations.AddDiskSerialToRun do
   use Ecto.Migration
 
   def change do
-    alter table :runs do
+    alter table(:runs) do
       add :disk_serial, :string
     end
   end

--- a/ui/priv/repo/migrations/20250729105500_add_disk_serial_to_run.exs
+++ b/ui/priv/repo/migrations/20250729105500_add_disk_serial_to_run.exs
@@ -1,0 +1,9 @@
+defmodule ExNVR.Repo.Migrations.AddDiskSerialToRun do
+  use Ecto.Migration
+
+  def change do
+    alter table :runs do
+      add :disk_serial, :string
+    end
+  end
+end


### PR DESCRIPTION
Adding disk serial to the runs allows the tracking of available footages across all the hdds.