### PR TITLE
Allow generic events of of content type json only

### DIFF
--- a/ui/lib/ex_nvr_web/controllers/api/event_controller.ex
+++ b/ui/lib/ex_nvr_web/controllers/api/event_controller.ex
@@ -11,15 +11,22 @@ defmodule ExNVRWeb.API.EventController do
 
   @spec create(Conn.t(), map()) :: Conn.t()
   def create(conn, params) do
-    device = conn.assigns.device
+    headers =
+      Enum.into(conn.req_headers, %{})
 
-    event_params =
-      params
-      |> Map.put("metadata", conn.body_params)
-      |> Map.put("time", generic_event_time(params, device.timezone))
+    if headers["content-type"] == "application/json" do
+      device = conn.assigns.device
 
-    with {:ok, _event} <- Events.create_event(device, event_params) do
-      send_resp(conn, 201, "")
+      event_params =
+        params
+        |> Map.put("metadata", conn.body_params)
+        |> Map.put("time", generic_event_time(params, device.timezone))
+
+      with {:ok, _event} <- Events.create_event(device, event_params) do
+        send_resp(conn, 201, "")
+      end
+    else
+      send_resp(conn, 415, "Unsupported Content Type")
     end
   end
 

--- a/ui/test/ex_nvr_web/controllers/api/event_controller_test.exs
+++ b/ui/test/ex_nvr_web/controllers/api/event_controller_test.exs
@@ -29,6 +29,8 @@ defmodule ExNVRWeb.Api.EventControllerTest do
     "motion_level" => 9000
   }
 
+  @generic_event_unsupported_media_type "location: kitchen"
+
   setup %{tmp_dir: tmp_dir} do
     device =
       camera_device_fixture(tmp_dir, %{
@@ -57,6 +59,7 @@ defmodule ExNVRWeb.Api.EventControllerTest do
 
     test "create a new generic event", %{conn: conn, device: device, token: token} do
       conn
+      |> put_req_header("content-type", "application/json")
       |> post(
         ~p"/api/devices/#{device.id}/events?type=my_type&token=#{token}",
         @generic_event
@@ -70,6 +73,20 @@ defmodule ExNVRWeb.Api.EventControllerTest do
       assert event.type == "my_type"
     end
 
+    test "return unsupported content type when content is not json", %{
+      conn: conn,
+      device: device,
+      token: token
+    } do
+      conn
+      |> put_req_header("content-type", "text/plain")
+      |> post(
+        ~p"/api/devices/#{device.id}/events?type=my_type&token=#{token}",
+        @generic_event_unsupported_media_type
+      )
+      |> response(415)
+    end
+
     test "return bad_argument when type is missing", %{
       conn: conn,
       device: device,
@@ -77,6 +94,7 @@ defmodule ExNVRWeb.Api.EventControllerTest do
     } do
       response =
         conn
+        |> put_req_header("content-type", "application/json")
         |> post(
           ~p"/api/devices/#{device.id}/events?token=#{token}",
           %{}
@@ -117,6 +135,7 @@ defmodule ExNVRWeb.Api.EventControllerTest do
       payload = %{"time" => dz_naive_time}
 
       conn
+      |> put_req_header("content-type", "application/json")
       |> post(
         ~p"/api/devices/#{device.id}/events?type=my_type&token=#{token}",
         payload
@@ -139,6 +158,7 @@ defmodule ExNVRWeb.Api.EventControllerTest do
       payload = %{"time" => dz_time}
 
       conn
+      |> put_req_header("content-type", "application/json")
       |> post(
         ~p"/api/devices/#{device.id}/events?type=my_type&token=#{token}",
         payload
@@ -157,6 +177,7 @@ defmodule ExNVRWeb.Api.EventControllerTest do
       token: token
     } do
       conn
+      |> put_req_header("content-type", "application/json")
       |> post(
         ~p"/api/devices/#{device.id}/events?type=my_type&token=#{token}",
         @generic_event


### PR DESCRIPTION
- fixes: https://github.com/evercam/ex_nvr/issues/753

Reason for error occurrence:
The API is not designed to handle any other content-type other than application/json. Hence the the server crashes. 

Solution:
filter the content type and give a more descriptive error than (500). To 415


<img width="338" height="126" alt="image" src="https://github.com/user-attachments/assets/34483f66-26bb-471b-a543-0d855f646c6f" />
