### PR TITLE
Add device options to control recording

### DIFF
--- a/ui/lib/ex_nvr/devices.ex
+++ b/ui/lib/ex_nvr/devices.ex
@@ -40,6 +40,7 @@ defmodule ExNVR.Devices do
     |> Repo.update()
     |> case do
       {:ok, updated_device} ->
+        create_device_directories(updated_device)
         start_or_stop_supervisor(device, updated_device)
         {:ok, updated_device}
 
@@ -129,12 +130,16 @@ defmodule ExNVR.Devices do
 
   @spec create_device_directories(ExNVR.Model.Device.t()) :: :ok
   def create_device_directories(device) do
-    File.mkdir_p!(Device.base_dir(device))
-    File.mkdir_p!(Device.recording_dir(device))
-    File.mkdir_p!(Device.recording_dir(device, :low))
-    File.mkdir_p!(Device.bif_dir(device))
-    File.mkdir_p!(Device.bif_thumbnails_dir(device))
-    File.mkdir_p!(Device.lpr_thumbnails_dir(device))
+    if Device.base_dir(device) do
+      File.mkdir_p!(Device.base_dir(device))
+      File.mkdir_p!(Device.recording_dir(device))
+      File.mkdir_p!(Device.recording_dir(device, :low))
+      File.mkdir_p!(Device.bif_dir(device))
+      File.mkdir_p!(Device.bif_thumbnails_dir(device))
+      File.mkdir_p!(Device.lpr_thumbnails_dir(device))
+    end
+
+    :ok
   end
 
   @spec summary :: list()

--- a/ui/lib/ex_nvr/devices/supervisor.ex
+++ b/ui/lib/ex_nvr/devices/supervisor.ex
@@ -20,13 +20,22 @@ defmodule ExNVR.Devices.Supervisor do
   @impl true
   def init(device) do
     params = [device: device]
+    recording_mode = Device.recording_mode(device)
 
-    children = [
-      {ExNVR.DiskMonitor, params},
-      {Main, params},
-      {ExNVR.BIF.GeneratorServer, params},
-      {ExNVR.Devices.SnapshotUploader, params}
-    ]
+    children =
+      if recording_mode == :never do
+        [
+          {Main, params},
+          {ExNVR.Devices.SnapshotUploader, params}
+        ]
+      else
+        [
+          {ExNVR.DiskMonitor, params},
+          {Main, params},
+          {ExNVR.BIF.GeneratorServer, params},
+          {ExNVR.Devices.SnapshotUploader, params}
+        ]
+      end
 
     children =
       if device.settings.enable_lpr && Device.http_url(device) do

--- a/ui/lib/ex_nvr/disk_monitor.ex
+++ b/ui/lib/ex_nvr/disk_monitor.ex
@@ -64,8 +64,9 @@ defmodule ExNVR.DiskMonitor do
     end
   end
 
-  defp get_disk_info(mountpoint) do
+  defp get_disk_info(path) do
     :disksup.get_disk_info()
-    |> Enum.find(fn {mp, _, _, _} -> to_string(mp) == mountpoint end)
+    |> Enum.filter(fn {mp, _, _, _} -> String.starts_with?(path, to_string(mp)) end)
+    |> Enum.max_by(fn {mp, _, _, _} -> byte_size(to_string(mp)) end, fn -> nil end)
   end
 end

--- a/ui/lib/ex_nvr/model/device.ex
+++ b/ui/lib/ex_nvr/model/device.ex
@@ -243,7 +243,15 @@ defmodule ExNVR.Model.Device do
 
   # directories path
 
-  @spec base_dir(t()) :: Path.t()
+  @spec recording_mode(t()) :: :never | :always | :on_event
+  def recording_mode(%__MODULE__{storage_config: %{recording_mode: mode}}) when not is_nil(mode),
+    do: mode
+
+  def recording_mode(%__MODULE__{}), do: :always
+
+  @spec base_dir(t()) :: Path.t() | nil
+  def base_dir(%__MODULE__{storage_config: %{address: nil}}), do: nil
+
   def base_dir(%__MODULE__{id: id, storage_config: %{address: path}}),
     do: Path.join([path, "ex_nvr", id])
 

--- a/ui/lib/ex_nvr/model/device/storage_config.ex
+++ b/ui/lib/ex_nvr/model/device/storage_config.ex
@@ -11,6 +11,7 @@ defmodule ExNVR.Model.Device.StorageConfig do
 
   @primary_key false
   embedded_schema do
+    field :recording_mode, Ecto.Enum, values: [:never, :always, :on_event], default: :always
     field :address, :string
     # full drive
     field :full_drive_threshold, :float, default: 95.0
@@ -36,7 +37,14 @@ defmodule ExNVR.Model.Device.StorageConfig do
   @spec update_changeset(t(), map()) :: Ecto.Changeset.t()
   def update_changeset(struct, params) do
     struct
-    |> cast(params, [:full_drive_threshold, :full_drive_action, :record_sub_stream, :schedule])
+    |> cast(params, [
+      :recording_mode,
+      :address,
+      :full_drive_threshold,
+      :full_drive_action,
+      :record_sub_stream,
+      :schedule
+    ])
     |> common_changeset()
   end
 
@@ -47,12 +55,22 @@ defmodule ExNVR.Model.Device.StorageConfig do
       greater_than_or_equal_to: 0,
       message: "value must be between 0 and 100"
     )
-    |> validate_required([:address])
+    |> maybe_require_address()
     |> validate_change(:schedule, fn :schedule, schedule ->
       case Schedule.validate(schedule) do
         {:ok, _schedule} -> []
         {:error, _reason} -> [schedule: "Invalid schedule"]
       end
     end)
+  end
+
+  defp maybe_require_address(changeset) do
+    recording_mode = get_field(changeset, :recording_mode)
+
+    if recording_mode != :never do
+      validate_required(changeset, [:address])
+    else
+      changeset
+    end
   end
 end

--- a/ui/lib/ex_nvr/pipeline/storage_monitor.ex
+++ b/ui/lib/ex_nvr/pipeline/storage_monitor.ex
@@ -27,10 +27,12 @@ defmodule ExNVR.Pipeline.StorageMonitor do
   def init(opts) do
     device = Keyword.fetch!(opts, :device)
     schedule = device.storage_config.schedule
+    recording_mode = Device.recording_mode(device)
 
     state = %{
       pipeline_pid: Keyword.fetch!(opts, :pipeline_pid),
       device: device,
+      recording_mode: recording_mode,
       schedule: schedule && Schedule.parse!(schedule),
       dir: Device.base_dir(device),
       schedule_timer: nil,
@@ -39,7 +41,11 @@ defmodule ExNVR.Pipeline.StorageMonitor do
       paused?: false
     }
 
-    {:ok, state, {:continue, :record?}}
+    if recording_mode == :never do
+      {:ok, notify_parent(state, false)}
+    else
+      {:ok, state, {:continue, :record?}}
+    end
   end
 
   @impl true
@@ -116,6 +122,7 @@ defmodule ExNVR.Pipeline.StorageMonitor do
     %{state | record?: record?}
   end
 
+  defp record?(%{recording_mode: :never}), do: false
   defp record?(%{schedule: nil}), do: true
 
   defp record?(%{schedule: schedule} = state) do

--- a/ui/lib/ex_nvr/pipelines/main.ex
+++ b/ui/lib/ex_nvr/pipelines/main.ex
@@ -504,7 +504,9 @@ defmodule ExNVR.Pipelines.Main do
   end
 
   defp build_sub_stream_bif_spec(state) do
-    if state.record_main_stream? and state.device.settings.generate_bif do
+    has_address = not is_nil(state.device.storage_config.address)
+
+    if has_address and state.device.settings.generate_bif do
       [
         get_child({:tee, :sub_stream})
         |> via_out(:push_output)

--- a/ui/lib/ex_nvr_web/live/device_live.html.heex
+++ b/ui/lib/ex_nvr_web/live/device_live.html.heex
@@ -229,66 +229,102 @@
         <div class="flex flex-col text-black dark:text-white">
           <.inputs_for :let={storage_config} field={@device_form[:storage_config]}>
             <div class="w-full mb-5 font-medium bg-gray-300 dark:bg-gray-800">
-              <h2 class="mb-2">Select storage address</h2>
-              <.input
-                :let={option}
-                field={storage_config[:address]}
-                id="settings-storage-address"
-                type="radio"
-                options={@disks_data}
-                disabled={not is_nil(@device.id)}
-              >
-                <div class="w-full px-2 font-normal text-xs">
-                  <div class="flex justify-between mb-1">
-                    <span class="text-black dark:text-white">
-                      {elem(option, 0)}
-                    </span>
-                    <span class="text-black dark:text-white">
-                      {humanize_capacity(elem(option, 1))}
-                    </span>
-                  </div>
-                  <div class="w-full bg-gray-200 rounded-full dark:bg-gray-700">
-                    <div
-                      class="bg-blue-800 text-xs font-medium text-blue-100 text-center leading-none rounded-full"
-                      style={"width: #{elem(option, 1) |> elem(1)}%"}
-                    >
-                      {elem(option, 1) |> elem(1)}%
-                    </div>
-                  </div>
+              <div class="grid grid-cols-3 gap-5 items-center my-5">
+                <span class="col-span-2">Recording mode:</span>
+                <.input
+                  field={storage_config[:recording_mode]}
+                  id="settings-recording-mode"
+                  type="select"
+                  label=""
+                  options={[
+                    {"Always", "always"},
+                    {"Never", "never"}
+                  ]}
+                />
+              </div>
+              <div :if={@recording_mode != "never"}>
+                <div class="flex items-center justify-between mt-4 mb-2">
+                  <h2>Storage address</h2>
+                  <button
+                    type="button"
+                    class="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                    phx-click="toggle_storage_address_mode"
+                  >
+                    {if @storage_address_mode == "volume",
+                      do: "Use custom path",
+                      else: "Select volume"}
+                  </button>
                 </div>
-              </.input>
-              <div
-                :if={@device_type == "ip" || @device_type == "webcam"}
-                class="grid grid-cols-3 gap-5 items-center my-5"
-              >
-                <span class="col-span-2">Full drive threshold:</span>
-                <.input
-                  field={storage_config[:full_drive_threshold]}
-                  type="number"
-                  label=""
-                  min="0"
-                  max="99"
-                />
+                <div :if={@storage_address_mode == "volume"}>
+                  <.input
+                    :let={option}
+                    field={storage_config[:address]}
+                    id="settings-storage-address"
+                    type="radio"
+                    options={@disks_data}
+                  >
+                    <div class="w-full px-2 font-normal text-xs">
+                      <div class="flex justify-between mb-1">
+                        <span class="text-black dark:text-white">
+                          {elem(option, 0)}
+                        </span>
+                        <span class="text-black dark:text-white">
+                          {humanize_capacity(elem(option, 1))}
+                        </span>
+                      </div>
+                      <div class="w-full bg-gray-200 rounded-full dark:bg-gray-700">
+                        <div
+                          class="bg-blue-800 text-xs font-medium text-blue-100 text-center leading-none rounded-full"
+                          style={"width: #{elem(option, 1) |> elem(1)}%"}
+                        >
+                          {elem(option, 1) |> elem(1)}%
+                        </div>
+                      </div>
+                    </div>
+                  </.input>
+                </div>
+                <div :if={@storage_address_mode == "custom"}>
+                  <.input
+                    field={storage_config[:address]}
+                    id="settings-storage-address-custom"
+                    type="text"
+                    label=""
+                    placeholder="/path/to/storage"
+                  />
+                </div>
+                <div
+                  :if={@device_type == "ip" || @device_type == "webcam"}
+                  class="grid grid-cols-3 gap-5 items-center my-5"
+                >
+                  <span class="col-span-2">Full drive threshold:</span>
+                  <.input
+                    field={storage_config[:full_drive_threshold]}
+                    type="number"
+                    label=""
+                    min="0"
+                    max="99"
+                  />
 
-                <span class="col-span-2">Full drive action:</span>
-                <.input
-                  field={storage_config[:full_drive_action]}
-                  type="select"
-                  label=""
-                  options={[{"nothing", "nothing"}, {"overwrite", "overwrite"}]}
-                />
+                  <span class="col-span-2">Full drive action:</span>
+                  <.input
+                    field={storage_config[:full_drive_action]}
+                    type="select"
+                    label=""
+                    options={[{"nothing", "nothing"}, {"overwrite", "overwrite"}]}
+                  />
 
-                <span class="col-span-2">Record sub stream:</span>
-                <.input
-                  field={storage_config[:record_sub_stream]}
-                  type="select"
-                  label=""
-                  options={[{"never", "never"}, {"always", "always"}]}
-                />
+                  <span class="col-span-2">Record sub stream:</span>
+                  <.input
+                    field={storage_config[:record_sub_stream]}
+                    type="select"
+                    label=""
+                    options={[{"never", "never"}, {"always", "always"}]}
+                  />
+                </div>
               </div>
             </div>
 
-            <div class="flex items-center gap-4 mb-2">
+            <div :if={@recording_mode != "never"} class="flex items-center gap-4 mb-2">
               <.vue
                 v-component="ScheduleFormInput"
                 class="e-h-full"
@@ -350,13 +386,17 @@
             </.inputs_for>
           </div>
         </div>
-        <div :if={@device_type == "ip"} class="flex flex-col">
+        <div :if={@device_type == "ip" && @recording_mode != "never"} class="flex flex-col">
           <div class="relative flex py-5 items-center">
             <span class="flex-shrink mr-4 text-black dark:text-white">Other Settings</span>
             <div class="flex-grow border-t border-gray-400"></div>
           </div>
           <.inputs_for :let={settings} field={@device_form[:settings]}>
-            <.input field={settings[:generate_bif]} type="checkbox" label="Generate BIF" />
+            <.input
+              field={settings[:generate_bif]}
+              type="checkbox"
+              label="Generate BIF"
+            />
             <.input field={settings[:enable_lpr]} type="checkbox" label="Pull LPR events" />
           </.inputs_for>
         </div>

--- a/ui/test/ex_nvr/devices_test.exs
+++ b/ui/test/ex_nvr/devices_test.exs
@@ -498,4 +498,66 @@ defmodule ExNVR.DevicesTest do
 
     assert Path.join([ctx.tmp_dir, "ex_nvr", device.id, "bif"]) == Device.bif_dir(device)
   end
+
+  describe "recording_mode" do
+    test "defaults to :always for new devices", %{tmp_dir: tmp_dir} do
+      device = camera_device_fixture(tmp_dir)
+      assert device.storage_config.recording_mode == :always
+      assert Device.recording_mode(device) == :always
+    end
+
+    test "create device with recording_mode :never does not require address" do
+      {:ok, device} =
+        Devices.create(
+          valid_device_attributes(%{
+            storage_config: %{recording_mode: :never, address: nil}
+          })
+        )
+
+      assert device.storage_config.recording_mode == :never
+      assert device.storage_config.address == nil
+    end
+
+    test "create device with recording_mode :never does not create directories" do
+      {:ok, device} =
+        Devices.create(
+          valid_device_attributes(%{
+            storage_config: %{recording_mode: :never, address: nil}
+          })
+        )
+
+      assert Device.base_dir(device) == nil
+    end
+
+    test "create device with recording_mode :always requires address" do
+      {:error, changeset} =
+        Devices.create(
+          valid_device_attributes(%{
+            storage_config: %{recording_mode: :always, address: nil}
+          })
+        )
+
+      assert %{storage_config: %{address: ["can't be blank"]}} = errors_on(changeset)
+    end
+
+    test "update device recording_mode", %{tmp_dir: tmp_dir} do
+      device = camera_device_fixture(tmp_dir)
+      assert device.storage_config.recording_mode == :always
+
+      {:ok, updated} =
+        Devices.update(device, %{storage_config: %{recording_mode: :never}})
+
+      assert updated.storage_config.recording_mode == :never
+    end
+
+    test "recording_mode helper defaults to :always for legacy devices" do
+      device = %Device{storage_config: %{recording_mode: nil}}
+      assert Device.recording_mode(device) == :always
+    end
+
+    test "base_dir returns nil when address is nil" do
+      device = %Device{id: "test-id", storage_config: %{address: nil}}
+      assert Device.base_dir(device) == nil
+    end
+  end
 end

--- a/ui/test/ex_nvr/pipeline/storage_monitor_test.exs
+++ b/ui/test/ex_nvr/pipeline/storage_monitor_test.exs
@@ -1,0 +1,67 @@
+defmodule ExNVR.Pipeline.StorageMonitorTest do
+  use ExUnit.Case, async: true
+
+  alias ExNVR.Model.Device
+  alias ExNVR.Pipeline.StorageMonitor
+
+  @moduletag :tmp_dir
+
+  defp build_device(tmp_dir, recording_mode) do
+    device = %Device{
+      id: "test-#{System.unique_integer([:positive])}",
+      timezone: "UTC",
+      storage_config: %Device.StorageConfig{
+        recording_mode: recording_mode,
+        address: if(recording_mode != :never, do: tmp_dir),
+        schedule: nil
+      }
+    }
+
+    if recording_mode != :never do
+      File.mkdir_p!(Device.base_dir(device))
+    end
+
+    device
+  end
+
+  describe "recording_mode :never" do
+    test "immediately sends record? false and does not continue", %{tmp_dir: tmp_dir} do
+      device = build_device(tmp_dir, :never)
+
+      {:ok, pid} = StorageMonitor.start_link(device: device, pipeline_pid: self())
+
+      assert_receive {:storage_monitor, :record?, false}
+      refute_receive {:storage_monitor, :record?, true}, 100
+
+      GenServer.stop(pid)
+    end
+  end
+
+  describe "recording_mode :always" do
+    test "sends record? true when directory is writable", %{tmp_dir: tmp_dir} do
+      device = build_device(tmp_dir, :always)
+
+      {:ok, pid} = StorageMonitor.start_link(device: device, pipeline_pid: self())
+
+      assert_receive {:storage_monitor, :record?, true}
+
+      GenServer.stop(pid)
+    end
+
+    test "pause and resume work", %{tmp_dir: tmp_dir} do
+      device = build_device(tmp_dir, :always)
+
+      {:ok, pid} = StorageMonitor.start_link(device: device, pipeline_pid: self())
+
+      assert_receive {:storage_monitor, :record?, true}
+
+      :ok = StorageMonitor.pause(pid)
+      assert_receive {:storage_monitor, :record?, false}
+
+      :ok = StorageMonitor.resume(pid)
+      assert_receive {:storage_monitor, :record?, true}
+
+      GenServer.stop(pid)
+    end
+  end
+end

--- a/ui/test/ex_nvr_web/live/device_live_test.exs
+++ b/ui/test/ex_nvr_web/live/device_live_test.exs
@@ -181,6 +181,143 @@ defmodule ExNVRWeb.DeviceLiveTest do
     end
   end
 
+  describe "Create device with recording_mode" do
+    test "create a device with recording_mode never (no address needed)", %{conn: conn} do
+      {:ok, lv, _} = live(conn, ~p"/devices/new")
+
+      {:ok, conn} =
+        lv
+        |> form("#device_form", %{
+          "device" => %{
+            "name" => "No Recording Device",
+            "type" => "ip",
+            "credentials" => %{
+              "username" => "user",
+              "password" => "pass"
+            },
+            "stream_config" => %{
+              "stream_uri" => "rtsp://localhost:554"
+            },
+            "storage_config" => %{
+              "recording_mode" => "never"
+            }
+          }
+        })
+        |> render_submit()
+        |> follow_redirect(conn, ~p"/devices")
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Device created successfully"
+
+      assert [device] = Devices.list()
+      assert device.storage_config.recording_mode == :never
+      assert device.storage_config.address == nil
+    end
+
+    test "create a device with recording_mode always requires address", %{conn: conn} do
+      {:ok, lv, _} = live(conn, ~p"/devices/new")
+
+      result =
+        lv
+        |> form("#device_form", %{
+          "device" => %{
+            "name" => "Recording Device",
+            "type" => "ip",
+            "credentials" => %{
+              "username" => "user",
+              "password" => "pass"
+            },
+            "stream_config" => %{
+              "stream_uri" => "rtsp://localhost:554"
+            },
+            "storage_config" => %{
+              "recording_mode" => "always"
+            }
+          }
+        })
+        |> render_submit()
+
+      assert result =~ "can&#39;t be blank"
+      assert Enum.empty?(Devices.list())
+    end
+
+    test "recording_mode never hides storage address in UI", %{conn: conn} do
+      {:ok, lv, _} = live(conn, ~p"/devices/new")
+
+      html =
+        render_change(lv, :validate, %{
+          "device" => %{
+            "storage_config" => %{"recording_mode" => "never"}
+          }
+        })
+
+      refute html =~ "Storage address"
+    end
+
+    test "recording_mode always shows storage address in UI", %{conn: conn} do
+      {:ok, lv, _} = live(conn, ~p"/devices/new")
+
+      html =
+        render_change(lv, :validate, %{
+          "device" => %{
+            "storage_config" => %{"recording_mode" => "always"}
+          }
+        })
+
+      assert html =~ "Storage address"
+    end
+
+    test "toggle between volume and custom path", %{conn: conn} do
+      {:ok, lv, html} = live(conn, ~p"/devices/new")
+
+      # Default: volume mode
+      assert html =~ "Use custom path"
+      refute html =~ ~s(id="settings-storage-address-custom")
+
+      # Toggle to custom
+      html = render_click(lv, "toggle_storage_address_mode")
+      assert html =~ "Select volume"
+      assert html =~ ~s(id="settings-storage-address-custom")
+
+      # Toggle back to volume
+      html = render_click(lv, "toggle_storage_address_mode")
+      assert html =~ "Use custom path"
+    end
+
+    test "create device with custom storage path", %{conn: conn} do
+      {:ok, lv, _} = live(conn, ~p"/devices/new")
+
+      # Toggle to custom path mode
+      render_click(lv, "toggle_storage_address_mode")
+
+      {:ok, conn} =
+        lv
+        |> form("#device_form", %{
+          "device" => %{
+            "name" => "Custom Path Device",
+            "type" => "ip",
+            "credentials" => %{
+              "username" => "user",
+              "password" => "pass"
+            },
+            "stream_config" => %{
+              "stream_uri" => "rtsp://localhost:554"
+            },
+            "storage_config" => %{
+              "recording_mode" => "always",
+              "address" => "/tmp"
+            }
+          }
+        })
+        |> render_submit()
+        |> follow_redirect(conn, ~p"/devices")
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Device created successfully"
+
+      assert [device] = Devices.list()
+      assert device.storage_config.address == "/tmp"
+    end
+  end
+
   describe "Update a device" do
     setup ctx do
       %{


### PR DESCRIPTION
Recording can now be always and none. It should support on-event in the future.

To prevent easy mistakes we present the Volume selector primarily but for easy development and customization there is now a small link to allow showing a text field to enter a custom URL.

Storage is now created if missing when updating a device.