### PR TITLE
Harden WebRTC signaling against peer lifecycle races

### DIFF
--- a/ui/assets/js/webrtc.js
+++ b/ui/assets/js/webrtc.js
@@ -39,19 +39,45 @@ window.onload = function (_event) {
             channel.leave()
         })
 
-    channel.on("offer", ({ data }) => {
+    // ICE candidates can arrive before we've finished applying the remote
+    // description; adding them too early throws. Buffer until the remote
+    // description is set, then flush.
+    let remoteDescriptionSet = false
+    const pendingCandidates = []
+
+    channel.on("offer", async ({ data }) => {
         log("Received offer: " + data)
 
-        pc.setRemoteDescription(JSON.parse(data))
-        pc.createAnswer().then(answer => {
-            pc.setLocalDescription(answer)
+        try {
+            await pc.setRemoteDescription(JSON.parse(data))
+            remoteDescriptionSet = true
+
+            for (const candidate of pendingCandidates.splice(0)) {
+                await pc.addIceCandidate(candidate)
+            }
+
+            const answer = await pc.createAnswer()
+            await pc.setLocalDescription(answer)
             channel.push("answer", JSON.stringify(answer))
-        })
+        } catch (err) {
+            log("Failed to handle offer: " + err)
+        }
     })
 
-    channel.on("ice_candidate", ({ data }) => {
+    channel.on("ice_candidate", async ({ data }) => {
         log("received new ice candidate: " + data)
-        pc.addIceCandidate(JSON.parse(data))
+        const candidate = JSON.parse(data)
+
+        if (!remoteDescriptionSet) {
+            pendingCandidates.push(candidate)
+            return
+        }
+
+        try {
+            await pc.addIceCandidate(candidate)
+        } catch (err) {
+            log("Failed to add ice candidate: " + err)
+        }
     })
 
     pc.onicecandidate = (event) => {
@@ -67,9 +93,13 @@ window.onload = function (_event) {
     }
 
     pc.onconnectionstatechange = (event) => {
-        if (pc.connectionState == "disconnected") {
-            alert("connection closed, refresh browser to retry")
+        log("connection state: " + pc.connectionState)
+
+        if (pc.connectionState == "failed" || pc.connectionState == "disconnected") {
+            alert("connection lost, refresh browser to retry")
+            channel.leave()
             pc.close()
+            socket.disconnect()
         }
     }
 

--- a/ui/lib/ex_nvr/pipeline/output/web_rtc.ex
+++ b/ui/lib/ex_nvr/pipeline/output/web_rtc.ex
@@ -138,7 +138,15 @@ defmodule ExNVR.Pipeline.Output.WebRTC do
 
   @impl true
   def handle_info({:ex_webrtc, pc, {:ice_candidate, candidate}}, _ctx, state) do
-    send(state.peers[pc], {:ice_candidate, ExWebRTC.ICECandidate.to_json(candidate)})
+    # The peer connection keeps generating ICE candidates for a short while after
+    # it has been removed from `peers` (failed connection / channel process down).
+    # Looking the peer up defensively avoids `send(nil, _)` crashing the sink and,
+    # with it, the whole device pipeline.
+    case Map.get(state.peers, pc) do
+      nil -> :ok
+      peer_id -> send(peer_id, {:ice_candidate, ExWebRTC.ICECandidate.to_json(candidate)})
+    end
+
     {[], state}
   end
 
@@ -204,19 +212,39 @@ defmodule ExNVR.Pipeline.Output.WebRTC do
   end
 
   defp handle_peer_message({:answer, peer_id, answer}, state) do
-    pc = find_peer_pc(state.peers, peer_id)
-
-    answer
-    |> SessionDescription.from_json()
-    |> then(&PeerConnection.set_remote_description(pc, &1))
+    with_peer_pc(state, peer_id, fn pc ->
+      answer
+      |> SessionDescription.from_json()
+      |> then(&PeerConnection.set_remote_description(pc, &1))
+    end)
   end
 
   defp handle_peer_message({:ice_candidate, peer_id, ice_candidate}, state) do
-    pc = find_peer_pc(state.peers, peer_id)
+    with_peer_pc(state, peer_id, fn pc ->
+      ice_candidate
+      |> ExWebRTC.ICECandidate.from_json()
+      |> then(&PeerConnection.add_ice_candidate(pc, &1))
+    end)
+  end
 
-    ice_candidate
-    |> ExWebRTC.ICECandidate.from_json()
-    |> then(&PeerConnection.add_ice_candidate(pc, &1))
+  # Runs `fun` with the peer connection for `peer_id`, but only if the peer is
+  # still registered. The peer may already be gone (the channel disconnected
+  # between sending the offer and us receiving the answer), and the peer
+  # connection process can also have died on its own. Either way we must not let
+  # a stray signaling message crash the sink and tear down the pipeline.
+  defp with_peer_pc(state, peer_id, fun) do
+    case find_peer_pc(state.peers, peer_id) do
+      nil ->
+        Membrane.Logger.debug("Ignoring signaling message for unknown WebRTC peer")
+
+      pc ->
+        fun.(pc)
+    end
+  rescue
+    error -> Membrane.Logger.warning("Failed to handle WebRTC peer message: #{inspect(error)}")
+  catch
+    :exit, reason ->
+      Membrane.Logger.warning("WebRTC peer connection no longer alive: #{inspect(reason)}")
   end
 
   defp send_video_packet(state, packet) do

--- a/ui/lib/ex_nvr_web/channels/device_room_channel.ex
+++ b/ui/lib/ex_nvr_web/channels/device_room_channel.ex
@@ -23,24 +23,31 @@ defmodule ExNVRWeb.DeviceRoomChannel do
 
   @impl true
   def handle_in("answer", answer, socket) do
-    MainPipeline.forward_peer_message(
-      socket.assigns.device,
-      socket.assigns.stream,
-      {:answer, Jason.decode!(answer)}
-    )
-
+    forward_decoded(socket, :answer, answer)
     {:noreply, socket}
   end
 
   @impl true
   def handle_in("ice_candidate", candidate, socket) do
-    MainPipeline.forward_peer_message(
-      socket.assigns.device,
-      socket.assigns.stream,
-      {:ice_candidate, Jason.decode!(candidate)}
-    )
-
+    forward_decoded(socket, :ice_candidate, candidate)
     {:noreply, socket}
+  end
+
+  # A misbehaving or malicious client could send a payload that is not valid
+  # JSON. Decoding defensively keeps that from crashing the channel (and forcing
+  # the whole session to re-join) over a single bad frame.
+  defp forward_decoded(socket, type, payload) do
+    case Jason.decode(payload) do
+      {:ok, data} ->
+        MainPipeline.forward_peer_message(
+          socket.assigns.device,
+          socket.assigns.stream,
+          {type, data}
+        )
+
+      {:error, _reason} ->
+        Logger.warning("Discarding malformed #{type} payload on device channel")
+    end
   end
 
   @impl true

--- a/ui/test/ex_nvr/pipeline/output/web_rtc_test.exs
+++ b/ui/test/ex_nvr/pipeline/output/web_rtc_test.exs
@@ -1,0 +1,99 @@
+defmodule ExNVR.Pipeline.Output.WebRTCTest do
+  @moduledoc """
+  Regression tests for the WebRTC sink's handling of stale or out-of-order
+  signaling. A peer (the channel process) and its peer connection can go away
+  at any time; messages referencing them must be dropped instead of crashing
+  the sink, which would tear down the whole device pipeline.
+
+  These tests exercise the sink's callbacks directly with a handcrafted state,
+  no real peer connections needed for the guard paths.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias ExNVR.Pipeline.Output.WebRTC
+
+  @moduletag :capture_log
+
+  @answer %{"type" => "answer", "sdp" => "v=0\r\n"}
+  @ice_candidate %{
+    "candidate" => "candidate:1 1 UDP 2122252543 192.168.1.10 51000 typ host",
+    "sdpMid" => "0",
+    "sdpMLineIndex" => 0
+  }
+
+  setup do
+    {[], state} = WebRTC.handle_init(%{}, %{ice_servers: []})
+    %{state: state}
+  end
+
+  describe "messages referencing unknown peers" do
+    test "local ice candidate from a removed peer connection is dropped", %{state: state} do
+      # The peer connection keeps emitting candidates for a short while after
+      # being removed from state (failed connection / channel down). This used
+      # to crash with `send(nil, _)`.
+      unknown_pc = self()
+
+      candidate = %ExWebRTC.ICECandidate{candidate: "candidate:1", sdp_mid: "0"}
+
+      assert {[], ^state} =
+               WebRTC.handle_info(
+                 {:ex_webrtc, unknown_pc, {:ice_candidate, candidate}},
+                 %{},
+                 state
+               )
+    end
+
+    test "answer for an unknown peer is ignored", %{state: state} do
+      assert {[], ^state} =
+               WebRTC.handle_parent_notification({:answer, self(), @answer}, %{}, state)
+    end
+
+    test "remote ice candidate for an unknown peer is ignored", %{state: state} do
+      assert {[], ^state} =
+               WebRTC.handle_parent_notification(
+                 {:ice_candidate, self(), @ice_candidate},
+                 %{},
+                 state
+               )
+    end
+  end
+
+  describe "messages referencing a dead peer connection" do
+    setup %{state: state} do
+      pc = spawn(fn -> :ok end)
+      ref = Process.monitor(pc)
+      assert_receive {:DOWN, ^ref, :process, ^pc, _reason}
+
+      state = %{
+        state
+        | peers: Map.put(state.peers, pc, self()),
+          peers_state: Map.put(state.peers_state, pc, :connected)
+      }
+
+      %{state: state, pc: pc}
+    end
+
+    test "answer does not crash the sink", %{state: state} do
+      assert {[], ^state} =
+               WebRTC.handle_parent_notification({:answer, self(), @answer}, %{}, state)
+    end
+
+    test "remote ice candidate does not crash the sink", %{state: state} do
+      assert {[], ^state} =
+               WebRTC.handle_parent_notification(
+                 {:ice_candidate, self(), @ice_candidate},
+                 %{},
+                 state
+               )
+    end
+  end
+
+  describe "buffers" do
+    test "are dropped when there are no peers", %{state: state} do
+      buffer = %Membrane.Buffer{payload: <<0, 0, 0, 1>>, pts: 0}
+
+      assert {[], ^state} = WebRTC.handle_buffer(:video, buffer, %{}, state)
+    end
+  end
+end


### PR DESCRIPTION
(Claude wrote this, I've seen issues with WebRTC and I wanted to see if there was obvious stuff to tidy up. I will try it later.)

The WebRTC sink could crash, taking down the whole device pipeline, when signaling messages raced against peer removal:

- A late ICE candidate from a peer connection already removed from state (failed connection or channel process down) hit send(state.peers[pc], ...) with nil and raised.
- An answer or remote ICE candidate for an unregistered peer passed nil to PeerConnection.set_remote_description/add_ice_candidate.
- A registered but dead peer connection process caused a :noproc exit.

Guard all three paths so stray signaling is logged and dropped instead of crashing the sink.

On the client, the offer handler called createAnswer without awaiting setRemoteDescription, and trickle ICE candidates arriving before the remote description was applied made addIceCandidate throw. Sequence the handshake with async/await and buffer early candidates until the remote description is set. Also handle the "failed" connection state, which was previously ignored.

The device channel now decodes signaling payloads with Jason.decode/1 instead of decode!/1 so a malformed frame no longer crashes the channel.

Add regression tests for the sink guards; 5 of 6 fail against the previous implementation.