### PR TITLE
fix: handle schedules missing day keys in SnapshotUploader (#15)

### DIFF
--- a/ui/lib/ex_nvr/devices/snapshot_uploader.ex
+++ b/ui/lib/ex_nvr/devices/snapshot_uploader.ex
@@ -6,7 +6,7 @@ defmodule ExNVR.Devices.SnapshotUploader do
   require Logger
 
   alias ExNVR.{Devices, RemoteStorages}
-  alias ExNVR.Model.Device
+  alias ExNVR.Model.{Device, Schedule}
   alias ExNVR.RemoteStorage
   alias ExNVR.RemoteStorages.Store
 
@@ -58,31 +58,27 @@ defmodule ExNVR.Devices.SnapshotUploader do
     utc_now = DateTime.utc_now()
     Process.send_after(self(), :upload_snapshot, :timer.seconds(snapshot_config.upload_interval))
 
-    with true <- scheduled?(device, snapshot_config.schedule) do
+    with true <- scheduled?(device, snapshot_config.schedule, utc_now) do
       fetch_and_upload_snapshot(remote_storage, device, utc_now, opts)
     end
 
     {:noreply, state}
   end
 
-  defp scheduled?(%{timezone: timezone}, schedule) do
-    now = DateTime.now!(timezone)
-    day_of_week = DateTime.to_date(now) |> Date.day_of_week() |> Integer.to_string()
+  @doc false
+  @spec scheduled?(Device.t(), map(), DateTime.t()) :: boolean()
+  def scheduled?(%{timezone: timezone}, schedule, utc_now \\ DateTime.utc_now()) do
+    case DateTime.shift_zone(utc_now, timezone) do
+      {:ok, now} ->
+        Schedule.scheduled?(schedule, now)
 
-    case Map.get(schedule, day_of_week) do
-      [] ->
-        false
+      {:error, reason} ->
+        Logger.warning(
+          "Cannot convert time to device timezone #{timezone} (#{inspect(reason)}), falling back to UTC"
+        )
 
-      time_intervals ->
-        scheduled_today?(time_intervals, DateTime.to_time(now))
+        Schedule.scheduled?(schedule, utc_now)
     end
-  end
-
-  defp scheduled_today?(time_intervals, current_time) do
-    Enum.any?(time_intervals, fn time_interval ->
-      Time.compare(time_interval.start_time, current_time) in [:lt, :eq] &&
-        Time.compare(current_time, time_interval.end_time) in [:lt, :eq]
-    end)
   end
 
   defp fetch_and_upload_snapshot(remote_storage, device, utc_now, opts) do

--- a/ui/test/ex_nvr/devices/snapshot_uploader_test.exs
+++ b/ui/test/ex_nvr/devices/snapshot_uploader_test.exs
@@ -1,0 +1,74 @@
+defmodule ExNVR.Devices.SnapshotUploaderTest do
+  use ExUnit.Case, async: true
+
+  alias ExNVR.Devices.SnapshotUploader
+  alias ExNVR.Model.{Device, Schedule}
+
+  # 2026-06-08 is a Monday ("1"), 2026-06-09 a Tuesday ("2")
+  @monday_morning ~U[2026-06-08 09:30:00Z]
+  @tuesday_morning ~U[2026-06-09 09:30:00Z]
+
+  defp device(timezone \\ "UTC"), do: %Device{timezone: timezone}
+
+  defp schedule(map), do: Schedule.parse!(map)
+
+  defp full_week_schedule(intervals) do
+    Map.new(1..7, fn day -> {Integer.to_string(day), intervals} end)
+  end
+
+  describe "scheduled?/3" do
+    test "returns true when current time falls within a scheduled interval" do
+      schedule = schedule(full_week_schedule(["08:00-17:00"]))
+
+      assert SnapshotUploader.scheduled?(device(), schedule, @monday_morning)
+    end
+
+    test "interval bounds are inclusive" do
+      schedule = schedule(full_week_schedule(["08:00-17:00"]))
+
+      assert SnapshotUploader.scheduled?(device(), schedule, ~U[2026-06-08 08:00:00Z])
+      assert SnapshotUploader.scheduled?(device(), schedule, ~U[2026-06-08 17:00:59Z])
+    end
+
+    test "returns false when current time is outside scheduled intervals" do
+      schedule = schedule(full_week_schedule(["08:00-17:00"]))
+
+      refute SnapshotUploader.scheduled?(device(), schedule, ~U[2026-06-08 07:59:59Z])
+      refute SnapshotUploader.scheduled?(device(), schedule, ~U[2026-06-08 18:00:00Z])
+    end
+
+    test "returns false when the current day has an empty schedule" do
+      schedule = schedule(%{"1" => ["08:00-17:00"], "2" => []})
+
+      refute SnapshotUploader.scheduled?(device(), schedule, @tuesday_morning)
+    end
+
+    test "returns false when the schedule is missing the current day key" do
+      # legacy/partial schedule maps may not contain entries for all days
+      schedule = schedule(%{"1" => ["08:00-17:00"]})
+
+      refute SnapshotUploader.scheduled?(device(), schedule, @tuesday_morning)
+    end
+
+    test "returns false for an empty schedule map" do
+      refute SnapshotUploader.scheduled?(device(), %{}, @monday_morning)
+    end
+
+    test "evaluates the schedule in the device timezone" do
+      # Monday 22:00 UTC is Tuesday 07:00 in Asia/Tokyo (UTC+9)
+      utc_now = ~U[2026-06-08 22:00:00Z]
+      schedule = schedule(%{"1" => [], "2" => ["06:00-08:00"]})
+
+      assert SnapshotUploader.scheduled?(device("Asia/Tokyo"), schedule, utc_now)
+      refute SnapshotUploader.scheduled?(device("UTC"), schedule, utc_now)
+    end
+
+    @tag capture_log: true
+    test "falls back to UTC when the device timezone cannot be resolved" do
+      schedule = schedule(%{"1" => ["08:00-17:00"]})
+
+      assert SnapshotUploader.scheduled?(device("Invalid/Timezone"), schedule, @monday_morning)
+      refute SnapshotUploader.scheduled?(device("Invalid/Timezone"), schedule, @tuesday_morning)
+    end
+  end
+end


### PR DESCRIPTION
A snapshot schedule map missing the current day's key (legacy/partial schedules) caused Enum.any?(nil) to crash the uploader. Delegate the check to ExNVR.Model.Schedule.scheduled?/2, which treats a missing day as not scheduled, and guard the timezone conversion (falling back to UTC with a warning) instead of raising via DateTime.now!/1.

Adds unit tests for the scheduling decision logic.