### PR TITLE
fix: handle devices with no recordings in delete_oldest_recordings (#9)

### DIFF
--- a/ui/lib/ex_nvr/disk_monitor.ex
+++ b/ui/lib/ex_nvr/disk_monitor.ex
@@ -28,12 +28,17 @@ defmodule ExNVR.DiskMonitor do
       send(self(), :tick)
     end
 
-    {:ok, %{device: options[:device], full_space_ticks: 0}}
+    {:ok,
+     %{
+       device: options[:device],
+       full_space_ticks: 0,
+       disk_usage_fun: options[:disk_usage_fun] || (&get_device_disk_usage/1)
+     }}
   end
 
   @impl true
   def handle_info(:tick, %{device: device, full_space_ticks: full_space_ticks} = state) do
-    used_space = get_device_disk_usage(device)
+    used_space = state.disk_usage_fun.(device)
     threshold = device.storage_config.full_drive_threshold
 
     Logger.debug("Disk usage percentage: #{used_space}%")
@@ -42,7 +47,7 @@ defmodule ExNVR.DiskMonitor do
       cond do
         used_space >= threshold and full_space_ticks >= @ticks_until_delete ->
           Logger.info("Deleting old recordings because of hard drive nearly full")
-          Recordings.delete_oldest_recordings(device, @max_recordings_to_delete)
+          delete_oldest_recordings(device)
           %{state | full_space_ticks: 0}
 
         used_space >= threshold ->
@@ -54,6 +59,22 @@ defmodule ExNVR.DiskMonitor do
 
     Process.send_after(self(), :tick, @interval_timer)
     {:noreply, state}
+  end
+
+  defp delete_oldest_recordings(device) do
+    case Recordings.delete_oldest_recordings(device, @max_recordings_to_delete) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to delete oldest recordings: #{inspect(reason)}")
+    end
+  rescue
+    exception ->
+      Logger.error(
+        "Unexpected error while deleting oldest recordings: " <>
+          Exception.format(:error, exception, __STACKTRACE__)
+      )
   end
 
   defp get_device_disk_usage(device) do

--- a/ui/lib/ex_nvr/recordings.ex
+++ b/ui/lib/ex_nvr/recordings.ex
@@ -239,11 +239,16 @@ defmodule ExNVR.Recordings do
   @spec delete_oldest_recordings(Device.t(), integer()) ::
           :ok | {:error, Ecto.Changeset.t()}
   def delete_oldest_recordings(device, limit) do
-    high_res_recordings =
-      Recording.with_type(:high)
-      |> Recording.oldest_recordings(device.id, limit)
-      |> Repo.all()
+    Recording.with_type(:high)
+    |> Recording.oldest_recordings(device.id, limit)
+    |> Repo.all()
+    |> case do
+      [] -> :ok
+      high_res_recordings -> do_delete_oldest_recordings(device, high_res_recordings)
+    end
+  end
 
+  defp do_delete_oldest_recordings(device, high_res_recordings) do
     low_res_recordings =
       Recording.with_type(:low)
       |> Recording.before_date(List.last(high_res_recordings).end_date)
@@ -306,8 +311,10 @@ defmodule ExNVR.Recordings do
     end)
     |> Multi.one(:"oldest_run_#{stream_type}", oldest_run_query)
     |> Multi.run(:"run_#{stream_type}", fn _repo, changes ->
-      if run = changes[:"oldest_run_#{stream_type}"] do
-        recording = changes[:"oldest_recording_#{stream_type}"]
+      run = changes[:"oldest_run_#{stream_type}"]
+      recording = changes[:"oldest_recording_#{stream_type}"]
+
+      if run && recording do
         Repo.update(Run.changeset(run, %{start_date: recording.start_date}))
       else
         {:ok, nil}

--- a/ui/test/ex_nvr/disk_monitor_test.exs
+++ b/ui/test/ex_nvr/disk_monitor_test.exs
@@ -1,0 +1,56 @@
+defmodule ExNVR.DiskMonitorTest do
+  @moduledoc false
+
+  use ExNVR.DataCase
+
+  alias ExNVR.DiskMonitor
+  alias ExNVR.Model.Recording
+
+  @moduletag :tmp_dir
+
+  # init/1 sends an initial tick, so 5 more ticks are
+  # needed to reach the delete threshold (ticks_until_delete)
+  @remaining_ticks_until_delete 5
+
+  setup ctx do
+    %{device: camera_device_fixture(ctx.tmp_dir)}
+  end
+
+  test "delete oldest recordings when drive is nearly full", %{device: device} do
+    start_date = ~U(2023-12-12 10:00:00Z)
+
+    run =
+      run_fixture(device,
+        start_date: start_date,
+        end_date: DateTime.add(start_date, 5 * 60)
+      )
+
+    Enum.each(
+      1..5,
+      &recording_fixture(device,
+        start_date: DateTime.add(start_date, &1 - 1, :minute),
+        end_date: DateTime.add(start_date, &1, :minute),
+        run: run
+      )
+    )
+
+    pid = start_disk_monitor(device)
+    Enum.each(1..@remaining_ticks_until_delete, fn _idx -> send(pid, :tick) end)
+
+    # synchronize with the monitor to make sure all ticks were handled
+    assert %{full_space_ticks: 0} = :sys.get_state(pid)
+    assert Repo.aggregate(Recording, :count) == 0
+  end
+
+  test "does not crash when the device has no recordings", %{device: device} do
+    pid = start_disk_monitor(device)
+    Enum.each(1..@remaining_ticks_until_delete, fn _idx -> send(pid, :tick) end)
+
+    assert %{full_space_ticks: 0} = :sys.get_state(pid)
+    assert Process.alive?(pid)
+  end
+
+  defp start_disk_monitor(device) do
+    start_supervised!({DiskMonitor, device: device, disk_usage_fun: fn _device -> 100 end})
+  end
+end

--- a/ui/test/ex_nvr/recordings/recordings_test.exs
+++ b/ui/test/ex_nvr/recordings/recordings_test.exs
@@ -114,6 +114,68 @@ defmodule ExNVR.RecordingTest do
     assert_files_deleted(device, :high, low_res_recordings_2, 4)
   end
 
+  describe "delete oldest recordings edge cases" do
+    test "device with no recordings", %{device: device} do
+      assert :ok = Recordings.delete_oldest_recordings(device, 30)
+
+      assert ExNVR.Repo.aggregate(Recording, :count) == 0
+      assert ExNVR.Repo.aggregate(Run, :count) == 0
+    end
+
+    test "device with only low resolution recordings", %{device: device} do
+      start_date = ~U(2023-12-12 10:00:00Z)
+
+      run =
+        run_fixture(device,
+          start_date: start_date,
+          end_date: DateTime.add(start_date, 10 * 60),
+          stream: :low
+        )
+
+      Enum.each(
+        1..10,
+        &recording_fixture(device,
+          start_date: DateTime.add(start_date, &1 - 1, :minute),
+          end_date: DateTime.add(start_date, &1, :minute),
+          run: run,
+          stream: :low
+        )
+      )
+
+      assert :ok = Recordings.delete_oldest_recordings(device, 30)
+
+      # without high resolution recordings as a reference point,
+      # low resolution recordings are kept
+      assert ExNVR.Repo.aggregate(Recording, :count) == 10
+      assert ExNVR.Repo.aggregate(Run, :count) == 1
+    end
+
+    test "limit is greater than the total number of recordings", %{device: device} do
+      start_date = ~U(2023-12-12 10:00:00Z)
+
+      run =
+        run_fixture(device,
+          start_date: start_date,
+          end_date: DateTime.add(start_date, 5 * 60)
+        )
+
+      recordings =
+        Enum.map(
+          1..5,
+          &recording_fixture(device,
+            start_date: DateTime.add(start_date, &1 - 1, :minute),
+            end_date: DateTime.add(start_date, &1, :minute),
+            run: run
+          )
+        )
+
+      assert :ok = Recordings.delete_oldest_recordings(device, 30)
+
+      assert ExNVR.Repo.aggregate(Recording, :count) == 0
+      assert_files_deleted(device, :high, recordings, 5)
+    end
+  end
+
   describe "get recordings details" do
     test "get recording details", %{device: device} do
       recording = recording_fixture(device)


### PR DESCRIPTION
`delete_oldest_recordings/2` crashed on devices with no high-res recordings (`List.last([]).end_date`) and again in `delete_recordings_multi/3` when a delete removed every recording. `DiskMonitor` neither rescued nor checked the return, and as first child of the `rest_for_one` device supervisor its crash restarted the whole device pipeline.

The function now no-ops with `:ok` when there are no high-res recordings, the oldest-run update only runs when both run and recording exist, and `DiskMonitor` logs error returns and rescues exceptions. Added a `disk_usage_fun` option for test injection; the supervisor is untouched.

Three new recordings tests (no recordings, low-res only, limit > total) fail with the nil-deref on master and pass with the fix. New `disk_monitor_test.exs` adds DiskMonitor's first tests (deletes when nearly full, survives zero recordings).