### PR TITLE
Main pipeline crash isolation

### DIFF
--- a/ui/lib/ex_nvr/pipelines/main.ex
+++ b/ui/lib/ex_nvr/pipelines/main.ex
@@ -261,6 +261,28 @@ defmodule ExNVR.Pipelines.Main do
   end
 
   @impl true
+  def handle_crash_group_down({:isolated, child_name} = group, ctx, state) do
+    # A child isolated by isolated_child/3 crashed; its crash group contained the
+    # failure. Re-derive its spec from the stream definition and restore it. On-demand
+    # children (binary stream, unix socket) aren't in the standing spec, so they stay
+    # down until a subscriber/socket reconnects and recreates them.
+    # NOTE: re-spawn is immediate with no backoff; a child that crashes deterministically
+    # on startup would restart-loop (a backoff/limit is a sensible follow-up).
+    with spec when not is_nil(spec) <- find_isolated_spec(group, state),
+         true <- Map.has_key?(ctx.children, source_tee(child_name)) do
+      Membrane.Logger.warning("Output #{inspect(child_name)} crashed, re-spawning it")
+      {[spec: spec], state}
+    else
+      _ -> {[], state}
+    end
+  end
+
+  @impl true
+  def handle_crash_group_down(_group, _ctx, state) do
+    {[], state}
+  end
+
+  @impl true
   def handle_info({:pipeline_supervisor, pid}, _ctx, state) do
     {[], %{state | supervisor_pid: pid}}
   end
@@ -477,11 +499,26 @@ defmodule ExNVR.Pipelines.Main do
   # Drop-in for child/3 that runs the child in its own :temporary crash group, so a
   # crash in it is contained instead of taking down the whole pipeline (notably the
   # source -> tee -> storage recording path). The group id is {:isolated, child_name}
-  # (group ids and child names share a namespace, so they must differ).
+  # (group ids and child names share a namespace, so they must differ);
+  # handle_crash_group_down/3 re-derives the child from the stream spec to restore it.
   defp isolated_child(builder, child_name, child_definition) do
     {child(builder, child_name, child_definition),
      group: {:isolated, child_name}, crash_group_mode: :temporary}
   end
+
+  # Re-derive a single isolated child's spec from the stream definition by matching its
+  # crash group id. Returns nil for on-demand children (binary stream, unix socket),
+  # which are not part of the standing spec and are recreated on reconnect.
+  defp find_isolated_spec(group, state) do
+    (build_main_stream_spec(state) ++ build_sub_stream_spec(state))
+    |> Enum.find(fn
+      {_builder, opts} when is_list(opts) -> opts[:group] == group
+      _ -> false
+    end)
+  end
+
+  defp source_tee({_name, :sub_stream}), do: {:tee, :sub_stream}
+  defp source_tee(_main_stream_child), do: :tee
 
   defp build_sub_stream_spec(%{device: device} = state) do
     [

--- a/ui/lib/ex_nvr/pipelines/main.ex
+++ b/ui/lib/ex_nvr/pipelines/main.ex
@@ -278,7 +278,7 @@ defmodule ExNVR.Pipelines.Main do
       spec = [
         source
         |> via_out(:push_output)
-        |> child(:unix_socket, ExNVR.Pipeline.Output.Socket)
+        |> isolated_child(:unix_socket, ExNVR.Pipeline.Output.Socket)
       ]
 
       {[spec: spec] ++ notify_action, state}
@@ -456,23 +456,31 @@ defmodule ExNVR.Pipelines.Main do
         get_child(:tee)
         |> via_out(:push_output)
         |> via_in(:video)
-        |> child(:hls_sink, %Output.HLS{
+        |> isolated_child(:hls_sink, %Output.HLS{
           location: Path.join(Utils.hls_dir(state.device.id), "live")
         }),
-        # |> get_child(:hls_sink),
         get_child(:tee)
         |> via_out(:push_output)
-        |> child({:snapshooter, :main_stream}, ExNVR.Elements.CVSBufferer),
+        |> isolated_child({:snapshooter, :main_stream}, ExNVR.Elements.CVSBufferer),
         get_child(:tee)
         |> via_out(:push_output)
-        |> child({:stats_reporter, :main_stream}, %VideoStreamStatReporter{
+        |> isolated_child({:stats_reporter, :main_stream}, %VideoStreamStatReporter{
           device_id: state.device.id
         }),
         get_child(:tee)
         |> via_out(:push_output)
         |> via_in(:video)
-        |> child(:webrtc, %Output.WebRTC{ice_servers: state.ice_servers})
+        |> isolated_child(:webrtc, %Output.WebRTC{ice_servers: state.ice_servers})
       ]
+  end
+
+  # Drop-in for child/3 that runs the child in its own :temporary crash group, so a
+  # crash in it is contained instead of taking down the whole pipeline (notably the
+  # source -> tee -> storage recording path). The group id is {:isolated, child_name}
+  # (group ids and child names share a namespace, so they must differ).
+  defp isolated_child(builder, child_name, child_definition) do
+    {child(builder, child_name, child_definition),
+     group: {:isolated, child_name}, crash_group_mode: :temporary}
   end
 
   defp build_sub_stream_spec(%{device: device} = state) do
@@ -480,18 +488,21 @@ defmodule ExNVR.Pipelines.Main do
       get_child({:tee, :sub_stream})
       |> via_out(:push_output)
       |> via_in(:video)
-      |> child({:hls_sink, :sub_stream}, %Output.HLS{
+      |> isolated_child({:hls_sink, :sub_stream}, %Output.HLS{
         location: Path.join(Utils.hls_dir(device.id, :low), "live")
       }),
       get_child({:tee, :sub_stream})
       |> via_out(:push_output)
-      |> child({:stats_reporter, :sub_stream}, %VideoStreamStatReporter{
+      |> isolated_child({:stats_reporter, :sub_stream}, %VideoStreamStatReporter{
         device_id: device.id,
         stream: :low
-      })
+      }),
+      get_child({:tee, :sub_stream})
+      |> via_out(:push_output)
+      |> via_in(:video)
+      |> isolated_child({:webrtc, :sub_stream}, %Output.WebRTC{ice_servers: state.ice_servers})
     ] ++
       build_sub_stream_storage_spec(device) ++
-      build_sub_stream_webrtc_spec(state) ++
       build_sub_stream_bif_spec(state)
   end
 
@@ -529,15 +540,6 @@ defmodule ExNVR.Pipelines.Main do
     end
   end
 
-  defp build_sub_stream_webrtc_spec(state) do
-    [
-      get_child({:tee, :sub_stream})
-      |> via_out(:push_output)
-      |> via_in(:video)
-      |> child({:webrtc, :sub_stream}, %Output.WebRTC{ice_servers: state.ice_servers})
-    ]
-  end
-
   defp build_sub_stream_bif_spec(state) do
     has_address = not is_nil(state.device.storage_config.address)
 
@@ -545,7 +547,7 @@ defmodule ExNVR.Pipelines.Main do
       [
         get_child({:tee, :sub_stream})
         |> via_out(:push_output)
-        |> child({:thumbnailer, :sub_stream}, %Output.Thumbnailer{
+        |> isolated_child({:thumbnailer, :sub_stream}, %Output.Thumbnailer{
           dest: Device.bif_thumbnails_dir(state.device)
         })
       ]
@@ -578,7 +580,7 @@ defmodule ExNVR.Pipelines.Main do
       [reply: reply] ++ notify
     else
       source = if stream_type == :high, do: get_child(:tee), else: get_child({:tee, :sub_stream})
-      spec = [source |> via_out(:push_output) |> child(child, BinaryStream)]
+      spec = [source |> via_out(:push_output) |> isolated_child(child, BinaryStream)]
       [reply: reply, spec: spec] ++ notify
     end
   end

--- a/ui/test/ex_nvr/pipelines/main_pipeline_test.exs
+++ b/ui/test/ex_nvr/pipelines/main_pipeline_test.exs
@@ -14,6 +14,11 @@ defmodule ExNVR.Pipelines.MainPipelineTest do
 
   @moduletag :tmp_dir
 
+  # Outputs that aren't part of the recording path each run in their own crash group
+  # (see ExNVR.Pipelines.Main.isolated_child/3); the recording spine
+  # (source -> tee -> storage) must survive any of them crashing.
+  @spine [:file_source, :tee]
+
   setup do
     %{device: file_device_fixture(%{state: :failed})}
   end
@@ -111,6 +116,47 @@ defmodule ExNVR.Pipelines.MainPipelineTest do
     assert :ok = Testing.Pipeline.terminate(pid)
   end
 
+  describe "crash isolation" do
+    test "crashing the WebRTC output does not take down the pipeline or recording spine",
+         %{device: device} do
+      pid = start_streaming_pipeline(device)
+
+      spine = capture_spine(pid)
+      sibling = {:snapshooter, :main_stream}
+      sibling_pid = await_child(pid, sibling)
+      webrtc_pid = await_child(pid, :webrtc)
+
+      watch(pid, spine)
+
+      Process.exit(webrtc_pid, :kill)
+
+      # Nothing on the recording spine (nor the pipeline) is torn down.
+      refute_receive {:DOWN, _ref, :process, _pid, _reason}, 1_000
+
+      assert_unchanged(pid, spine)
+      # Per-output isolation: a sibling output is undisturbed too.
+      assert {:ok, ^sibling_pid} = Testing.Pipeline.get_child_pid(pid, sibling)
+    end
+
+    test "crashing the HLS output does not take down the pipeline or recording spine",
+         %{device: device} do
+      pid = start_streaming_pipeline(device)
+
+      spine = capture_spine(pid)
+      webrtc_pid = await_child(pid, :webrtc)
+
+      watch(pid, spine)
+
+      hls_pid = await_child(pid, :hls_sink)
+      Process.exit(hls_pid, :kill)
+
+      refute_receive {:DOWN, _ref, :process, _pid, _reason}, 1_000
+
+      assert_unchanged(pid, spine)
+      assert {:ok, ^webrtc_pid} = Testing.Pipeline.get_child_pid(pid, :webrtc)
+    end
+  end
+
   defp prepare_pipeline(device) do
     options = [
       module: ExNVR.Pipelines.Main,
@@ -119,5 +165,56 @@ defmodule ExNVR.Pipelines.MainPipelineTest do
     ]
 
     Testing.Pipeline.start_link_supervised!(options)
+  end
+
+  defp start_streaming_pipeline(device) do
+    pid = prepare_pipeline(device)
+    # Wait until the main-stream track is seen; this is what triggers building the tee
+    # and the per-output children.
+    assert_pipeline_notified(pid, :file_source, {:main_stream, _tracks})
+    pid
+  end
+
+  defp capture_spine(pid), do: Map.new(@spine, &{&1, await_child(pid, &1)})
+
+  defp watch(pid, spine) do
+    Process.monitor(pid)
+    for {_child, child_pid} <- spine, do: Process.monitor(child_pid)
+    :ok
+  end
+
+  defp assert_unchanged(pid, spine) do
+    for {child, original} <- spine do
+      assert {:ok, ^original} = Testing.Pipeline.get_child_pid(pid, child)
+    end
+  end
+
+  defp await_child(pid, child, timeout \\ 5_000) do
+    await(timeout, "child #{inspect(child)} did not start", fn ->
+      case Testing.Pipeline.get_child_pid(pid, child) do
+        {:ok, child_pid} -> {:ok, child_pid}
+        {:error, _reason} -> :retry
+      end
+    end)
+  end
+
+  defp await(timeout, message, fun) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await(deadline, message, fun)
+  end
+
+  defp do_await(deadline, message, fun) do
+    case fun.() do
+      {:ok, value} ->
+        value
+
+      :retry ->
+        if System.monotonic_time(:millisecond) > deadline do
+          flunk(message)
+        else
+          Process.sleep(25)
+          do_await(deadline, message, fun)
+        end
+    end
   end
 end

--- a/ui/test/ex_nvr/pipelines/main_pipeline_test.exs
+++ b/ui/test/ex_nvr/pipelines/main_pipeline_test.exs
@@ -157,6 +157,28 @@ defmodule ExNVR.Pipelines.MainPipelineTest do
     end
   end
 
+  describe "crash recovery" do
+    test "a crashed WebRTC output is re-spawned", %{device: device} do
+      pid = start_streaming_pipeline(device)
+      webrtc_pid = await_child(pid, :webrtc)
+
+      Process.exit(webrtc_pid, :kill)
+
+      new_pid = await_respawn(pid, :webrtc, webrtc_pid)
+      assert Process.alive?(new_pid)
+    end
+
+    test "a crashed HLS output is re-spawned", %{device: device} do
+      pid = start_streaming_pipeline(device)
+      hls_pid = await_child(pid, :hls_sink)
+
+      Process.exit(hls_pid, :kill)
+
+      new_pid = await_respawn(pid, :hls_sink, hls_pid)
+      assert Process.alive?(new_pid)
+    end
+  end
+
   defp prepare_pipeline(device) do
     options = [
       module: ExNVR.Pipelines.Main,
@@ -194,6 +216,15 @@ defmodule ExNVR.Pipelines.MainPipelineTest do
       case Testing.Pipeline.get_child_pid(pid, child) do
         {:ok, child_pid} -> {:ok, child_pid}
         {:error, _reason} -> :retry
+      end
+    end)
+  end
+
+  defp await_respawn(pid, child, old_pid, timeout \\ 3_000) do
+    await(timeout, "child #{inspect(child)} was not re-spawned", fn ->
+      case Testing.Pipeline.get_child_pid(pid, child) do
+        {:ok, new_pid} when new_pid != old_pid -> {:ok, new_pid}
+        _ -> :retry
       end
     end)
   end


### PR DESCRIPTION
This should make the main pipeline much more resistant to failures in webrtc, hls, stats or whatever other extras we add on the tee.

It uses membrane crash groups to capture failures and then restore the lost bit of pipeline without needing to kill the main pipeline and disrupting writing to storage when that's fine.