### PR TITLE
fix: release NIF resources on constructor failure

### DIFF
--- a/video_processor/c_src/video_processor.c
+++ b/video_processor/c_src/video_processor.c
@@ -22,6 +22,7 @@ ERL_NIF_TERM new_encoder(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   encoder_config.profile = FF_PROFILE_UNKNOWN;
 
   char *codec_name = NULL, *format = NULL, *profile = NULL;
+  struct NvrEncoder *nvr_encoder = NULL;
 
   ErlNifMapIterator iter;
   ERL_NIF_TERM key, value;
@@ -74,6 +75,9 @@ ERL_NIF_TERM new_encoder(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
       goto clean;
     }
 
+    enif_free(config_name);
+    config_name = NULL;
+
     enif_map_iterator_next(env, &iter);
   }
 
@@ -110,7 +114,7 @@ ERL_NIF_TERM new_encoder(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     }
   }
 
-  struct NvrEncoder *nvr_encoder =
+  nvr_encoder =
       enif_alloc_resource(encoder_resource_type, sizeof(struct NvrEncoder));
 
   nvr_encoder->encoder = encoder_alloc();
@@ -122,10 +126,11 @@ ERL_NIF_TERM new_encoder(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   }
 
   ret = enif_make_resource(env, nvr_encoder);
-  enif_release_resource(nvr_encoder);
 
 clean:
   // clean encoder
+  if (nvr_encoder)
+    enif_release_resource(nvr_encoder);
   if (codec_name)
     enif_free(codec_name);
   if (format)
@@ -152,6 +157,7 @@ ERL_NIF_TERM new_decoder(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   ERL_NIF_TERM ret;
   char *codec_name = NULL, *out_format = NULL;
   const AVCodec *codec = NULL;
+  struct NvrDecoder *nvr_decoder = NULL;
   int out_width, out_height, pad;
 
   if (!nif_get_atom(env, argv[0], &codec_name)) {
@@ -191,7 +197,7 @@ ERL_NIF_TERM new_decoder(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 
   enum AVPixelFormat out_pix_fmt = av_get_pix_fmt(out_format);
 
-  struct NvrDecoder *nvr_decoder =
+  nvr_decoder =
       enif_alloc_resource(decoder_resource_type, sizeof(struct NvrDecoder));
 
   nvr_decoder->decoder = decoder_alloc();
@@ -208,9 +214,11 @@ ERL_NIF_TERM new_decoder(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   }
 
   ret = enif_make_resource(env, nvr_decoder);
-  enif_release_resource(nvr_decoder);
 
 clean:
+  if (nvr_decoder)
+    enif_release_resource(nvr_decoder);
+
   if (codec_name)
     enif_free(codec_name);
 
@@ -227,6 +235,7 @@ ERL_NIF_TERM new_converter(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) 
 
   ERL_NIF_TERM ret;
   char *in_format = NULL, *out_format = NULL;
+  struct NvrConverter *nvr_converter = NULL;
   int in_width, in_height, out_width, out_height, pad;
 
   if (!enif_get_int(env, argv[0], &in_width)) {
@@ -267,7 +276,7 @@ ERL_NIF_TERM new_converter(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) 
   enum AVPixelFormat in_pix_fmt = av_get_pix_fmt(in_format);
   enum AVPixelFormat out_pix_fmt = av_get_pix_fmt(out_format);
 
-  struct NvrConverter *nvr_converter =
+  nvr_converter =
       enif_alloc_resource(converter_resource_type, sizeof(struct NvrConverter));
 
 
@@ -285,9 +294,11 @@ ERL_NIF_TERM new_converter(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) 
   }
 
   ret = enif_make_resource(env, nvr_converter);
-  enif_release_resource(nvr_converter);
 
 clean:
+  if (nvr_converter)
+    enif_release_resource(nvr_converter);
+
   if (in_format)
     enif_free(in_format);
 

--- a/video_processor/test/decoder_test.exs
+++ b/video_processor/test/decoder_test.exs
@@ -2,6 +2,7 @@ defmodule ExNVR.AV.DecoderTest do
   use ExUnit.Case, async: true
 
   alias ExNVR.AV.{Decoder, Frame}
+  alias ExNVR.AV.VideoProcessor.NIF
 
   @h264_frame File.read!("test/fixtures/decoder/sample.h264")
   @h265_frame File.read!("test/fixtures/decoder/sample.h265")
@@ -14,6 +15,14 @@ defmodule ExNVR.AV.DecoderTest do
     assert is_reference(decoder)
 
     assert_raise(FunctionClauseError, fn -> Decoder.new(:vp8) end)
+  end
+
+  test "repeated failed constructions with an unknown codec raise a controlled error" do
+    for _i <- 1..1000 do
+      assert_raise ErlangError, ~r/unknown_codec/, fn ->
+        NIF.new_decoder(:vp9, -1, -1, nil, 0)
+      end
+    end
   end
 
   describe "decode/2" do

--- a/video_processor/test/encoder_test.exs
+++ b/video_processor/test/encoder_test.exs
@@ -19,6 +19,31 @@ defmodule ExNVR.AV.EncoderTest do
     test "raises on invalid encoder" do
       assert_raise FunctionClauseError, fn -> Encoder.new(:hevc, []) end
     end
+
+    test "raises on unknown option" do
+      assert_raise ErlangError, ~r/unknown_config_key/, fn ->
+        Encoder.new(:h264,
+          width: 360,
+          height: 240,
+          format: :yuv420p,
+          time_base: {1, 25},
+          unknown_option: 1
+        )
+      end
+    end
+
+    test "repeated failed constructions with an invalid config raise a controlled error" do
+      for _i <- 1..1000 do
+        assert_raise ErlangError, ~r/failed_to_init_encoder/, fn ->
+          Encoder.new(:h264,
+            width: 0,
+            height: 0,
+            format: :yuv420p,
+            time_base: {1, 90_000}
+          )
+        end
+      end
+    end
   end
 
   describe "encode/1" do

--- a/video_processor/test/video_processor_test.exs
+++ b/video_processor/test/video_processor_test.exs
@@ -18,6 +18,22 @@ defmodule ExNVR.AV.VideoProcessorTest do
 
       assert is_reference(converter)
     end
+
+    test "repeated failed constructions with an invalid config raise a controlled error" do
+      for _i <- 1..1000 do
+        assert_raise ErlangError, ~r/failed_to_init_converter/, fn ->
+          VideoProcessor.new_converter(
+            in_width: 0,
+            in_height: 0,
+            in_format: :yuv420p,
+            out_width: -1,
+            out_height: -1,
+            out_format: :rgb24,
+            pad?: false
+          )
+        end
+      end
+    end
   end
 
   describe "convert/2" do


### PR DESCRIPTION
new_encoder/new_decoder/new_converter allocate their resource with enif_alloc_resource before initialization. When init failed, the error path skipped enif_release_resource, leaving the refcount at 1 forever and leaking the resource struct along with its AVFrames/AVPackets and codec contexts on every failed constructor call.

Release the resource on the init-failure path in all three constructors; the registered destructors already handle the partially-initialized state defensively.

Also free the config_name buffer at the end of every iteration of the encoder options-parsing loop instead of only freeing the last one at cleanup, which leaked one small allocation per map key beyond the first on every encoder construction.