### PR TITLE
Make device pipeline startup resilient and retrying

### DIFF
--- a/ui/lib/ex_nvr/devices.ex
+++ b/ui/lib/ex_nvr/devices.ex
@@ -193,10 +193,27 @@ defmodule ExNVR.Devices do
     if run_pipeline?() do
       list()
       |> Enum.filter(&Device.recording?/1)
-      |> Enum.each(&Supervisor.start/1)
+      |> Enum.each(&start_recording_pipeline/1)
     end
 
     :ok
+  end
+
+  # A single device failing to start must not abort the whole batch; log it so a
+  # "started but not recording" device is observable instead of a silent boot.
+  defp start_recording_pipeline(%Device{} = device) do
+    case Supervisor.start(device) do
+      {:error, {:already_started, _pid}} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "Could not start recording pipeline for device #{device.id}: #{inspect(reason)}"
+        )
+
+      _started ->
+        :ok
+    end
   end
 
   defp start_or_stop_supervisor(%Device{} = device, nil) do

--- a/ui/lib/ex_nvr/pipeline_starter.ex
+++ b/ui/lib/ex_nvr/pipeline_starter.ex
@@ -1,0 +1,75 @@
+defmodule ExNVR.PipelineStarter do
+  @moduledoc """
+  Starts the device recording pipelines once at boot.
+
+  This replaces a previous unsupervised one-shot `Task`. Starting the pipelines
+  reads the devices from the database and prepares storage directories; both can
+  fail transiently at boot (database momentarily locked, storage not yet
+  mounted). Rather than dying and leaving the NVR running while recording
+  nothing — booting "healthy" but never recording — this process retries with a
+  capped backoff and only stops once the pipelines have been started.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @default_initial_backoff to_timeout(second: 1)
+  @default_max_backoff to_timeout(second: 30)
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      # Stops `:normal` once the pipelines are started, so a transient restart
+      # does not re-run it; an unexpected crash is still retried.
+      restart: :transient
+    }
+  end
+
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @impl true
+  def init(opts) do
+    state = %{
+      start_fun: Keyword.get(opts, :start_fun, &ExNVR.start/0),
+      backoff: Keyword.get(opts, :initial_backoff, @default_initial_backoff),
+      max_backoff: Keyword.get(opts, :max_backoff, @default_max_backoff)
+    }
+
+    # Do the work outside `init/1` so the supervision tree boots without
+    # blocking on the database / filesystem.
+    send(self(), :start)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:start, state) do
+    case run(state.start_fun) do
+      :ok ->
+        {:stop, :normal, state}
+
+      {:error, formatted} ->
+        Logger.error("""
+        Failed to start device pipelines, retrying in #{state.backoff}ms
+        #{formatted}
+        """)
+
+        Process.send_after(self(), :start, state.backoff)
+        {:noreply, %{state | backoff: min(state.backoff * 2, state.max_backoff)}}
+    end
+  end
+
+  defp run(start_fun) do
+    start_fun.()
+    :ok
+  rescue
+    error -> {:error, Exception.format(:error, error, __STACKTRACE__)}
+  catch
+    kind, reason -> {:error, Exception.format(kind, reason, __STACKTRACE__)}
+  end
+end

--- a/ui/lib/ex_nvr_web/application.ex
+++ b/ui/lib/ex_nvr_web/application.ex
@@ -29,7 +29,7 @@ defmodule ExNVRWeb.Application do
         {ExNVRWeb.HlsStreamingMonitor, []},
         {DynamicSupervisor, [name: ExNVR.Hardware.Supervisor, strategy: :one_for_one]},
         {ExNVR.Hardware.SerialPortChecker, []},
-        Task.child_spec(fn -> ExNVR.start() end)
+        {ExNVR.PipelineStarter, []}
       ] ++ trigger_listener() ++ remote_connector()
 
     opts = [strategy: :one_for_one, name: ExNVRWeb.Supervisor]

--- a/ui/test/ex_nvr/pipeline_starter_test.exs
+++ b/ui/test/ex_nvr/pipeline_starter_test.exs
@@ -1,0 +1,72 @@
+defmodule ExNVR.PipelineStarterTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  @moduletag capture_log: true
+
+  alias ExNVR.PipelineStarter
+
+  setup do
+    # Trap exits so the `:normal` stop of the (linked) starter is delivered
+    # deterministically, regardless of how fast it finishes.
+    Process.flag(:trap_exit, true)
+    :ok
+  end
+
+  defp start_starter(start_fun, opts \\ []) do
+    PipelineStarter.start_link(
+      [name: nil, start_fun: start_fun, initial_backoff: 5, max_backoff: 50] ++ opts
+    )
+  end
+
+  test "stops normally without retrying when the start function succeeds" do
+    test_pid = self()
+    start_fun = fn -> send(test_pid, :started) end
+
+    {:ok, pid} = start_starter(start_fun)
+
+    assert_receive :started
+    assert_receive {:EXIT, ^pid, :normal}
+    refute_received :started
+  end
+
+  test "retries with backoff and eventually stops once the start function succeeds" do
+    test_pid = self()
+    counter = :counters.new(1, [])
+
+    start_fun = fn ->
+      attempt = :counters.get(counter, 1)
+      :counters.add(counter, 1, 1)
+      send(test_pid, {:attempt, attempt})
+      # Fail the first two attempts (transient DB lock / storage hiccup at boot).
+      if attempt < 2, do: raise("boom")
+    end
+
+    {:ok, pid} = start_starter(start_fun)
+
+    assert_receive {:attempt, 0}
+    assert_receive {:attempt, 1}
+    assert_receive {:attempt, 2}
+    assert_receive {:EXIT, ^pid, :normal}
+    refute_received {:attempt, 3}
+  end
+
+  test "keeps retrying without crashing when the start function throws" do
+    test_pid = self()
+    counter = :counters.new(1, [])
+
+    start_fun = fn ->
+      attempt = :counters.get(counter, 1)
+      :counters.add(counter, 1, 1)
+      send(test_pid, {:attempt, attempt})
+      if attempt < 1, do: throw(:nope)
+    end
+
+    {:ok, pid} = start_starter(start_fun)
+
+    assert_receive {:attempt, 0}
+    assert_receive {:attempt, 1}
+    assert_receive {:EXIT, ^pid, :normal}
+  end
+end


### PR DESCRIPTION
Retry with backoff to recover from failed initial startup of cameras.