### PR TITLE
fix: test unmatchable case in sub stream startup

### DIFF
--- a/ui/lib/ex_nvr/pipelines/main.ex
+++ b/ui/lib/ex_nvr/pipelines/main.ex
@@ -313,7 +313,7 @@ defmodule ExNVR.Pipelines.Main do
     main_stream_spec = build_main_stream_storage_spec(state)
 
     sub_stream_spec =
-      build_sub_stream_storage_spec(state.device) ++ build_sub_stream_bif_spec(state)
+      build_sub_stream_storage_spec(state) ++ build_sub_stream_bif_spec(state)
 
     case {state.main_stream_video_track, state.sub_stream_video_track} do
       {nil, nil} ->
@@ -490,7 +490,7 @@ defmodule ExNVR.Pipelines.Main do
         stream: :low
       })
     ] ++
-      build_sub_stream_storage_spec(device) ++
+      build_sub_stream_storage_spec(state) ++
       build_sub_stream_webrtc_spec(state) ++
       build_sub_stream_bif_spec(state)
   end
@@ -511,7 +511,7 @@ defmodule ExNVR.Pipelines.Main do
 
   defp build_sub_stream_storage_spec(%{record_main_stream?: false}), do: []
 
-  defp build_sub_stream_storage_spec(device) do
+  defp build_sub_stream_storage_spec(%{device: device}) do
     case device.storage_config.record_sub_stream do
       :always ->
         [

--- a/ui/test/ex_nvr/pipelines/main_sub_stream_storage_test.exs
+++ b/ui/test/ex_nvr/pipelines/main_sub_stream_storage_test.exs
@@ -1,0 +1,47 @@
+defmodule ExNVR.Pipelines.MainSubStreamStorageTest do
+  use ExNVR.DataCase
+
+  import ExNVR.DevicesFixtures
+
+  alias ExNVR.Pipeline.Track
+  alias ExNVR.Pipelines.Main
+  alias ExNVR.Pipelines.Main.State
+
+  @ctx %{}
+
+  @moduletag :tmp_dir
+
+  setup do
+    %{track: %Track{type: :video, encoding: :h264}}
+  end
+
+  defp sub_stream_storage_attached?(device, recording, track) do
+    state = %State{device: device, record_main_stream?: recording}
+
+    {actions, _state} =
+      Main.handle_child_notification({:sub_stream, %{1 => track}}, :sub_stream, @ctx, state)
+
+    actions
+    |> Keyword.get(:spec, [])
+    |> inspect(limit: :infinity)
+    |> String.contains?("{:storage, :sub_stream}")
+  end
+
+  test "attaches sub-stream storage when configured and recording", %{track: track} do
+    device = camera_device_fixture("/tmp", %{storage_config: %{record_sub_stream: :always}})
+
+    assert sub_stream_storage_attached?(device, true, track)
+  end
+
+  test "does not attach sub-stream storage while not recording", %{track: track} do
+    device = camera_device_fixture("/tmp", %{storage_config: %{record_sub_stream: :always}})
+
+    refute sub_stream_storage_attached?(device, false, track)
+  end
+
+  test "does not attach sub-stream storage when sub-stream recording is disabled", %{track: track} do
+    device = camera_device_fixture("/tmp", %{storage_config: %{record_sub_stream: :never}})
+
+    refute sub_stream_storage_attached?(device, true, track)
+  end
+end


### PR DESCRIPTION
Wrong value being passed made sub stream pipeline always start.