### PR TITLE
fix: validate input binary size before av_image_fill_arrays

### DIFF
--- a/video_processor/c_src/video_processor.c
+++ b/video_processor/c_src/video_processor.c
@@ -326,6 +326,19 @@ ERL_NIF_TERM encode(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   frame->format = nvr_encoder->encoder->c->pix_fmt;
   frame->pts = pts;
 
+  // The input binary must hold a full frame for these dimensions and pixel
+  // format. av_image_fill_arrays below points the frame planes into input.data,
+  // so a too-short binary makes libx264 read past its end (heap overread / VM
+  // crash). Reject undersized input before filling.
+  int required_size =
+      av_image_get_buffer_size(frame->format, frame->width, frame->height, 1);
+  if (required_size < 0) {
+    return nif_raise(env, "failed_to_fill_arrays");
+  }
+  if (input.size < (size_t)required_size) {
+    return nif_raise(env, "invalid_input_size");
+  }
+
   ret = av_image_fill_arrays(frame->data, frame->linesize, input.data,
                              frame->format, frame->width, frame->height, 1);
   if (ret < 0) {
@@ -403,6 +416,19 @@ ERL_NIF_TERM convert(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   }
 
   AVFrame *frame = nvr_converter->frame;
+
+  // The input binary must hold a full frame for these dimensions and pixel
+  // format. av_image_fill_arrays below points the frame planes into input.data,
+  // so a too-short binary makes libswscale read past its end (heap overread / VM
+  // crash). Reject undersized input before filling.
+  int required_size =
+      av_image_get_buffer_size(frame->format, frame->width, frame->height, 1);
+  if (required_size < 0) {
+    return nif_raise(env, "failed_to_fill_arrays");
+  }
+  if (input.size < (size_t)required_size) {
+    return nif_raise(env, "invalid_input_size");
+  }
 
   ret = av_image_fill_arrays(frame->data, frame->linesize, input.data,
                              frame->format, frame->width, frame->height, 1);

--- a/video_processor/test/encoder_test.exs
+++ b/video_processor/test/encoder_test.exs
@@ -78,6 +78,28 @@ defmodule ExNVR.AV.EncoderTest do
       assert Enum.all?(packets, & &1.keyframe?)
     end
 
+    test "accepts data of exactly the required size and rejects one byte short", %{
+      frame: frame
+    } do
+      encoder =
+        Encoder.new(:h264,
+          width: 360,
+          height: 240,
+          format: :yuv420p,
+          time_base: {1, 25}
+        )
+
+      # The fixture is a complete 360x240 yuv420p frame, i.e. exactly the
+      # required size: it encodes, but one byte short must be rejected.
+      assert is_list(Encoder.encode(encoder, frame))
+
+      one_byte_short = %{frame | data: binary_part(frame.data, 0, byte_size(frame.data) - 1)}
+
+      assert_raise ErlangError, ~r/invalid_input_size/, fn ->
+        Encoder.encode(encoder, one_byte_short)
+      end
+    end
+
     test "no bframes inserted", %{frame: frame} do
       encoder =
         Encoder.new(:h264,

--- a/video_processor/test/video_processor_test.exs
+++ b/video_processor/test/video_processor_test.exs
@@ -44,6 +44,23 @@ defmodule ExNVR.AV.VideoProcessorTest do
       assert byte_size(converted_data) == 180 * 120 * 3
     end
 
+    test "accepts input of exactly the required size and rejects one byte short", %{
+      data: data,
+      options: options
+    } do
+      converter = VideoProcessor.new_converter(options)
+
+      # The fixture is a complete 360x240 yuv420p frame, i.e. exactly the
+      # required input size: it converts, but one byte short must be rejected.
+      assert is_binary(VideoProcessor.convert(converter, data))
+
+      one_byte_short = binary_part(data, 0, byte_size(data) - 1)
+
+      assert_raise ErlangError, ~r/invalid_input_size/, fn ->
+        VideoProcessor.convert(converter, one_byte_short)
+      end
+    end
+
     test "convert and pad a frame", %{data: data, options: options} do
       converter =
         VideoProcessor.new_converter(Keyword.merge(options, pad?: true, out_height: 180))


### PR DESCRIPTION
The encode and convert NIFs filled the AVFrame planes from the input binary and only checked for fill failures. A binary smaller than a full frame for the configured dimensions and pixel format made libx264/libswscale read past its end (heap overread, potential VM crash). Compute the required size up front with av_image_get_buffer_size and reject undersized input in both paths before any read.