### PR TITLE
feat(nerves): monitor generator state in giraffe board

### DIFF
--- a/nerves_fw/lib/nerves_fw/giraffe/init.ex
+++ b/nerves_fw/lib/nerves_fw/giraffe/init.ex
@@ -5,14 +5,15 @@ defmodule ExNVR.Nerves.Giraffe.Init do
   The following actions will be run at startup:
     * Power on HDD (GPIO16)
     * Power on PoE (GPIO26)
+    * Monitor status of GPIO10 (Generator)
   """
 
   use GenServer, restart: :transient
 
   require Logger
 
-  alias Circuits.GPIO
-  alias ExNVR.Nerves.SystemSettings
+  alias ExNVR.Nerves.GPIO
+  alias ExNVR.Nerves.{SystemSettings, SystemStatus}
 
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, nil)
@@ -42,10 +43,32 @@ defmodule ExNVR.Nerves.Giraffe.Init do
   end
 
   @impl true
-  def handle_continue(:init, state) do
-    :ok = GPIO.write_one("GPIO16", 1)
-    :ok = GPIO.write_one("GPIO26", 1)
+  def handle_continue(:init, _state) do
+    :ok = Circuits.GPIO.write_one("GPIO16", 1)
+    :ok = Circuits.GPIO.write_one("GPIO26", 1)
 
-    {:stop, :normal, state}
+    {:ok, generator_pid} = GPIO.start_link(pin: "GPIO10")
+    state = %{generator: %{pid: generator_pid, state: generator_state(GPIO.value(generator_pid))}}
+
+    {:noreply, state}
   end
+
+  @impl true
+  def handle_info({gen_pid, value}, %{generator: %{pid: gen_pid}} = state) do
+    status =
+      case value do
+        0 -> :on
+        1 -> :off
+      end
+
+    :ok = SystemStatus.set(:generator, status)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  defp generator_state(0), do: :on
+  defp generator_state(_), do: :off
 end

--- a/nerves_fw/lib/nerves_fw/giraffe/init.ex
+++ b/nerves_fw/lib/nerves_fw/giraffe/init.ex
@@ -48,20 +48,15 @@ defmodule ExNVR.Nerves.Giraffe.Init do
     :ok = Circuits.GPIO.write_one("GPIO26", 1)
 
     {:ok, generator_pid} = GPIO.start_link(pin: "GPIO10")
-    state = %{generator: %{pid: generator_pid, state: generator_state(GPIO.value(generator_pid))}}
+    state = %{generator: generator_pid}
+    :ok = SystemStatus.set(:generator, generator_state(GPIO.value(generator_pid)))
 
     {:noreply, state}
   end
 
   @impl true
-  def handle_info({gen_pid, value}, %{generator: %{pid: gen_pid}} = state) do
-    status =
-      case value do
-        0 -> :on
-        1 -> :off
-      end
-
-    :ok = SystemStatus.set(:generator, status)
+  def handle_info({gen_pid, value}, %{generator: gen_pid} = state) do
+    :ok = SystemStatus.set(:generator, generator_state(value))
     {:noreply, state}
   end
 

--- a/nerves_fw/lib/nerves_fw/monitoring/ups.ex
+++ b/nerves_fw/lib/nerves_fw/monitoring/ups.ex
@@ -9,7 +9,7 @@ defmodule ExNVR.Nerves.Monitoring.UPS do
 
   alias ExNVR.{Devices, Model, Pipelines}
   alias ExNVR.Nerves.{DiskMounter, SystemSettings}
-  alias ExNVR.Nerves.GPIO
+  alias ExNVR.Nerves.{GPIO, SystemStatus}
 
   def start_link(options) do
     GenServer.start_link(__MODULE__, options, name: __MODULE__)
@@ -63,6 +63,7 @@ defmodule ExNVR.Nerves.Monitoring.UPS do
 
     :ok = clean_state(state)
     new_state = do_start_monitor(ups_settings, [])
+    set_system_status(state)
 
     {:noreply, new_state, {:continue, :trigger_action}}
   end
@@ -125,6 +126,8 @@ defmodule ExNVR.Nerves.Monitoring.UPS do
     event = %{type: event_name(key), metadata: %{state: value}}
 
     Logger.info("[UPS] store event for #{key}")
+
+    set_system_status(state)
 
     with {:error, changeset} <- ExNVR.Events.create_event(event) do
       Logger.error("Failed to save event: #{inspect(changeset)}")
@@ -212,5 +215,18 @@ defmodule ExNVR.Nerves.Monitoring.UPS do
       :low_battery? ->
         if GPIO.value(state.bat_pid) != state.config.battery_pin_default, do: :down, else: :up
     end
+  end
+
+  defp set_system_status(%{config: %{enabled: false}}) do
+    :ok = SystemStatus.set(:ups, nil)
+  end
+
+  defp set_system_status(state) do
+    ups = %{
+      ac_ok: pin_state(state, :ac_ok?) == :up,
+      low_battery: pin_state(state, :low_battery?) == :down
+    }
+
+    :ok = SystemStatus.set(:ups, ups)
   end
 end

--- a/nerves_fw/lib/nerves_fw/monitoring/ups.ex
+++ b/nerves_fw/lib/nerves_fw/monitoring/ups.ex
@@ -63,7 +63,7 @@ defmodule ExNVR.Nerves.Monitoring.UPS do
 
     :ok = clean_state(state)
     new_state = do_start_monitor(ups_settings, [])
-    set_system_status(state)
+    set_system_status(new_state)
 
     {:noreply, new_state, {:continue, :trigger_action}}
   end

--- a/nerves_fw/lib/nerves_fw/system_status.ex
+++ b/nerves_fw/lib/nerves_fw/system_status.ex
@@ -8,7 +8,6 @@ defmodule ExNVR.Nerves.SystemStatus do
 
   require Logger
 
-  alias ExNVR.Nerves.Monitoring.UPS
   alias ExNVR.Nerves.{Netbird, RUT, SystemSettings}
   alias Nerves.Runtime
 
@@ -19,11 +18,21 @@ defmodule ExNVR.Nerves.SystemStatus do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
+  def set(key, value) do
+    GenServer.cast(__MODULE__, {:set, key, value})
+  end
+
   @impl true
   def init(_options) do
     Process.send_after(self(), :collect_system_metrics, to_timeout(second: 2))
     {:ok, ref} = :timer.send_interval(@runs_summary_interval, :runs_summary)
     {:ok, %{timer_ref: ref}}
+  end
+
+  @impl true
+  def handle_cast({:set, key, value}, state) do
+    :ok = ExNVR.SystemStatus.set(key, value)
+    {:noreply, state}
   end
 
   @impl true
@@ -33,7 +42,6 @@ defmodule ExNVR.Nerves.SystemStatus do
     :ok = ExNVR.SystemStatus.set(:netbird, netbird())
     :ok = ExNVR.SystemStatus.set(:nerves, true)
     :ok = ExNVR.SystemStatus.set(:device_model, Runtime.KV.get("a.nerves_fw_platform"))
-    :ok = ExNVR.SystemStatus.set(:ups, ups_data())
 
     Process.send_after(self(), :collect_system_metrics, to_timeout(second: 30))
     {:noreply, state}
@@ -68,6 +76,10 @@ defmodule ExNVR.Nerves.SystemStatus do
       {:ok, data} -> data
       _error -> false
     end
+  catch
+    :exit, _error ->
+      Logger.warning("[SystemStatus] cannot get status of netbird")
+      false
   end
 
   defp rut_data do
@@ -75,12 +87,9 @@ defmodule ExNVR.Nerves.SystemStatus do
       {:ok, data} -> data
       _error -> nil
     end
-  end
-
-  defp ups_data do
-    case Process.whereis(UPS) do
-      pid when is_pid(pid) -> UPS.state(pid)
-      _other -> nil
-    end
+  catch
+    :exit, _error ->
+      Logger.warning("[SystemStatus] cannot get router information")
+      nil
   end
 end


### PR DESCRIPTION
Monitor the state of the generator in giraffe board, the state is included in the system status under the key: `generator` which have values `:on` and `:off`

Alongside there's some refactoring:

- Add catch exit to SystemStatus module to not crash if router and netbird info cannot be retrieved
- Make ups set the data on the system status immediately instead of waiting for the timer to request the state from the UPS.