### PR TITLE
Milesight: Enable all profiles on onvif discovery

### DIFF
--- a/ui/lib/ex_nvr/devices/cameras/http_client.ex
+++ b/ui/lib/ex_nvr/devices/cameras/http_client.ex
@@ -22,7 +22,12 @@ defmodule ExNVR.Devices.Cameras.HttpClient do
   """
   @callback stream_profiles(url(), camera_opts()) :: {:ok, [StreamProfile.t()]} | error()
 
-  @optional_callbacks fetch_lpr_event: 2, device_info: 2, stream_profiles: 2
+  @doc """
+  Set stream profile on camera.
+  """
+  @callback set_stream_profile(url(), StreamProfile.t(), camera_opts()) :: {:ok, map()} | error()
+
+  @optional_callbacks fetch_lpr_event: 2, device_info: 2, stream_profiles: 2, set_stream_profile: 3
 
   defmacro __using__(_opts) do
     quote location: :keep do
@@ -36,6 +41,9 @@ defmodule ExNVR.Devices.Cameras.HttpClient do
 
       @impl true
       def stream_profiles(_url, _opts), do: {:error, :not_implemented}
+
+      @impl true
+      def set_stream_profile(_url, _profile, _opts), do: {:error, :not_implemented}
 
       defoverridable fetch_lpr_event: 2, device_info: 2, stream_profiles: 2
     end

--- a/ui/lib/ex_nvr/devices/cameras/http_client.ex
+++ b/ui/lib/ex_nvr/devices/cameras/http_client.ex
@@ -45,7 +45,7 @@ defmodule ExNVR.Devices.Cameras.HttpClient do
       @impl true
       def set_stream_profile(_url, _profile, _opts), do: {:error, :not_implemented}
 
-      defoverridable fetch_lpr_event: 2, device_info: 2, stream_profiles: 2
+      defoverridable fetch_lpr_event: 2, device_info: 2, stream_profiles: 2, set_stream_profile: 3
     end
   end
 end

--- a/ui/lib/ex_nvr/devices/cameras/http_client.ex
+++ b/ui/lib/ex_nvr/devices/cameras/http_client.ex
@@ -27,7 +27,10 @@ defmodule ExNVR.Devices.Cameras.HttpClient do
   """
   @callback set_stream_profile(url(), StreamProfile.t(), camera_opts()) :: {:ok, map()} | error()
 
-  @optional_callbacks fetch_lpr_event: 2, device_info: 2, stream_profiles: 2, set_stream_profile: 3
+  @optional_callbacks fetch_lpr_event: 2,
+                      device_info: 2,
+                      stream_profiles: 2,
+                      set_stream_profile: 3
 
   defmacro __using__(_opts) do
     quote location: :keep do

--- a/ui/lib/ex_nvr/devices/cameras/http_client/milesight.ex
+++ b/ui/lib/ex_nvr/devices/cameras/http_client/milesight.ex
@@ -48,6 +48,20 @@ defmodule ExNVR.Devices.Cameras.HttpClient.Milesight do
     |> handle_http_response(&parse_stream_profiles_response/1)
   end
 
+  def set_stream_profile(url, %StreamProfile{} = profile, opts) do
+    url = url <> @operator_path <> "?action=set.video.general&format=json"
+    body = %{"streamList" => %{profile.name => map_stream_profile(profile)}}
+
+    url
+    |> HTTP.post(body, opts)
+    |> handle_http_response(fn body ->
+      case Jason.decode(body) do
+        {:ok, parsed} -> parsed
+        {:error, _reason} -> body
+      end
+    end)
+  end
+
   defp parse_system_response(body) do
     response = Jason.decode!(body)
 
@@ -88,6 +102,21 @@ defmodule ExNVR.Devices.Cameras.HttpClient.Milesight do
       mapper.("subStream", get_in(response, ["streamList", "subStream"])),
       mapper.("thirdStream", get_in(response, ["streamList", "thirdStream"]))
     ]
+  end
+
+  defp map_stream_profile(%StreamProfile{} = profile) do
+    %{
+      enable: if(profile.enabled, do: 1, else: 0),
+      profileCodec: profile_codec_to_integer(profile.video_config.codec),
+      profile: profile_profile_to_integer(profile.video_config.codec_profile),
+      width: profile.video_config.width,
+      height: profile.video_config.height,
+      framerate: profile.video_config.frame_rate,
+      bitrate: profile.video_config.bitrate,
+      rateMode: bitrate_mode_to_integer(profile.video_config.bitrate_mode),
+      profileGop: profile.video_config.gop,
+      smartStreamEnable: if(profile.video_config.smart_codec, do: 1, else: 0)
+    }
   end
 
   defp parse_response(body, opts) do
@@ -184,14 +213,29 @@ defmodule ExNVR.Devices.Cameras.HttpClient.Milesight do
   defp profile_codec(3), do: :h265
   defp profile_codec(_other), do: :unknown
 
+  defp profile_codec_to_integer(:h264), do: 0
+  defp profile_codec_to_integer(:mpeg4), do: 1
+  defp profile_codec_to_integer(:mjpeg), do: 2
+  defp profile_codec_to_integer(:h265), do: 3
+  defp profile_codec_to_integer(_other), do: 0
+
   defp profile(0, 0), do: "base"
   defp profile(0, 1), do: "main"
   defp profile(0, 2), do: "high"
   defp profile(_codec, _other), do: nil
 
+  defp profile_profile_to_integer("base"), do: 0
+  defp profile_profile_to_integer("main"), do: 1
+  defp profile_profile_to_integer("high"), do: 2
+  defp profile_profile_to_integer(_other), do: 0
+
   defp bitrate_mode(0), do: :cbr
   defp bitrate_mode(1), do: :vbr
   defp bitrate_mode(_other), do: nil
+
+  defp bitrate_mode_to_integer(:cbr), do: 0
+  defp bitrate_mode_to_integer(:vbr), do: 1
+  defp bitrate_mode_to_integer(_other), do: 0
 
   defp handle_http_response({:ok, %{status: status, body: body}}, parser_fn)
        when status >= 200 and status < 300 do

--- a/ui/lib/ex_nvr_web/live/onvif_discovery_live.ex
+++ b/ui/lib/ex_nvr_web/live/onvif_discovery_live.ex
@@ -563,7 +563,9 @@ defmodule ExNVRWeb.OnvifDiscoveryLive do
 
   defp get_ntp(camera_details), do: camera_details
 
-  defp get_stream_profiles(%{device: %{manufacturer: "Milesight Technology Co.,Ltd."}} = camera_details) do
+  defp get_stream_profiles(
+         %{device: %{manufacturer: "Milesight Technology Co.,Ltd."}} = camera_details
+       ) do
     device = camera_details.device
     opts = [username: device.username, password: device.password]
 

--- a/ui/lib/ex_nvr_web/live/onvif_discovery_live.ex
+++ b/ui/lib/ex_nvr_web/live/onvif_discovery_live.ex
@@ -6,7 +6,7 @@ defmodule ExNVRWeb.OnvifDiscoveryLive do
   require Logger
 
   alias ExNVR.Devices
-  alias ExNVR.Devices.Cameras.{NetworkInterface, NTP, StreamProfile}
+  alias ExNVR.Devices.Cameras.{HttpClient.Milesight, NetworkInterface, NTP, StreamProfile}
 
   defmodule DiscoverSettings do
     @moduledoc false
@@ -562,6 +562,27 @@ defmodule ExNVRWeb.OnvifDiscoveryLive do
   end
 
   defp get_ntp(camera_details), do: camera_details
+
+  defp get_stream_profiles(%{device: %{manufacturer: "Milesight Technology Co.,Ltd."}} = camera_details) do
+    device = camera_details.device
+    opts = [username: device.username, password: device.password]
+
+    case Milesight.stream_profiles(device.address, opts) do
+      {:ok, profiles} ->
+        profiles = Enum.take(profiles, 3)
+
+        # Enable all profiles
+        profiles
+        |> Enum.reject(& &1.enabled)
+        |> Enum.each(&Milesight.set_stream_profile(device.address, %{&1 | enabled: true}, opts))
+
+        get_stream_uris(%{camera_details | stream_profiles: profiles})
+
+      {:error, reason} ->
+        Logger.error("Failed to get stream profiles for camera #{inspect(reason)}")
+        camera_details
+    end
+  end
 
   defp get_stream_profiles(%{device: %{media_ver20_service_path: nil}} = camera_details) do
     Logger.warning("[OnvifDiscovery] camera does not support onvif media version 2")


### PR DESCRIPTION
When in onvif discovery and the camera is Milesight, we use camera http API to request the stream profiles and enable the first 3.