### PR TITLE
Add victron probing config

### DIFF
--- a/nerves_fw/config/target.exs
+++ b/nerves_fw/config/target.exs
@@ -11,7 +11,8 @@ config :ex_nvr,
   admin_username: System.get_env("EXNVR_ADMIN_USERNAME", "admin@localhost"),
   admin_password: System.get_env("EXNVR_ADMIN_PASSWORD", "P@ssw0rd"),
   download_dir: System.get_env("EXNVR_DOWNLOAD_DIR", "/data/ex_nvr/downloads"),
-  mobius_persistence_dir: System.get_env("EXNVR_MOBIUS_DIR", "/data/ex_nvr/mobius")
+  mobius_persistence_dir: System.get_env("EXNVR_MOBIUS_DIR", "/data/ex_nvr/mobius"),
+  victron_probing: false
 
 config :ex_nvr, ice_servers: System.get_env("EXNVR_ICE_SERVERS", "[]")
 

--- a/ui/config/config.exs
+++ b/ui/config/config.exs
@@ -13,6 +13,9 @@ config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
 config :ex_nvr, env: :dev
 
+# Feature flags
+config :ex_nvr, victron_probing: false
+
 # Configure Mix tasks and generators
 config :ex_nvr,
   namespace: ExNVR,

--- a/ui/config/runtime.exs
+++ b/ui/config/runtime.exs
@@ -5,6 +5,10 @@ config :ex_nvr,
   admin_password: System.get_env("EXNVR_ADMIN_PASSWORD", "P@ssw0rd"),
   download_dir: System.get_env("EXNVR_DOWNLOAD_DIR")
 
+if victron_probing = System.get_env("EXNVR_VICTRON_PROBING") do
+  config :ex_nvr, victron_probing: victron_probing == "true"
+end
+
 if config_env() == :prod do
   config :ex_nvr, hls_directory: System.get_env("EXNVR_HLS_DIRECTORY", "./hls")
 

--- a/ui/lib/ex_nvr/hardware/serial_port_checker.ex
+++ b/ui/lib/ex_nvr/hardware/serial_port_checker.ex
@@ -81,7 +81,7 @@ defmodule ExNVR.Hardware.SerialPortChecker do
       |> Enum.reduce(state.started, fn args, acc ->
         case DynamicSupervisor.start_child(
                ExNVR.Hardware.Supervisor,
-               {ExNVR.Hardware.Victron, args}
+               {ExNVR.Hardware.Victron.Server, args}
              ) do
           {:ok, _pid} -> MapSet.put(acc, args[:name])
           _error -> acc

--- a/ui/lib/ex_nvr/hardware/serial_port_checker.ex
+++ b/ui/lib/ex_nvr/hardware/serial_port_checker.ex
@@ -17,26 +17,101 @@ defmodule ExNVR.Hardware.SerialPortChecker do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
+  @doc """
+  Enable Victron serial port probing.
+  """
+  @spec enable() :: :ok
+  def enable, do: GenServer.call(__MODULE__, :enable)
+
+  @doc """
+  Disable Victron serial port probing.
+  """
+  @spec disable() :: :ok
+  def disable, do: GenServer.call(__MODULE__, :disable)
+
+  @doc "Whether probing is currently enabled."
+  @spec enabled?() :: boolean()
+  def enabled?, do: GenServer.call(__MODULE__, :enabled?)
+
   @impl true
   def init(_opts) do
-    Process.send_after(self(), :check_serial_ports, 0)
-    {:ok, nil}
+    enabled? = Application.get_env(:ex_nvr, :victron_probing, false)
+    {:ok, schedule_check(%{enabled?: enabled?, timer: nil, started: MapSet.new()}, 0)}
   end
 
   @impl true
+  def handle_call(:enable, _from, %{enabled?: true} = state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:enable, _from, state) do
+    Logger.info("Enabling serial port probing")
+    {:reply, :ok, schedule_check(%{state | enabled?: true}, 0)}
+  end
+
+  def handle_call(:disable, _from, state) do
+    Logger.info("Disabling serial port probing")
+
+    state =
+      %{state | enabled?: false}
+      |> cancel_timer()
+      |> stop_started()
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:enabled?, _from, state) do
+    {:reply, state.enabled?, state}
+  end
+
+  @impl true
+  def handle_info(:check_serial_ports, %{enabled?: false} = state) do
+    {:noreply, %{state | timer: nil}}
+  end
+
   def handle_info(:check_serial_ports, state) do
     Logger.info("Checking for new serial ports")
-    Process.send_after(self(), :check_serial_ports, @serial_ports_interval_check)
 
-    Circuits.UART.enumerate()
-    |> Map.keys()
-    |> Kernel.--(@ignore_ports)
-    |> Enum.map(&[port: &1, name: :"victron_#{&1}"])
-    |> Enum.filter(&is_nil(Process.whereis(&1[:name])))
-    |> Enum.each(
-      &DynamicSupervisor.start_child(ExNVR.Hardware.Supervisor, {ExNVR.Hardware.Victron, &1})
-    )
+    started =
+      Circuits.UART.enumerate()
+      |> Map.keys()
+      |> Kernel.--(@ignore_ports)
+      |> Enum.map(&[port: &1, name: :"victron_#{&1}"])
+      |> Enum.filter(&is_nil(Process.whereis(&1[:name])))
+      |> Enum.reduce(state.started, fn args, acc ->
+        case DynamicSupervisor.start_child(
+               ExNVR.Hardware.Supervisor,
+               {ExNVR.Hardware.Victron, args}
+             ) do
+          {:ok, _pid} -> MapSet.put(acc, args[:name])
+          _error -> acc
+        end
+      end)
 
-    {:noreply, state}
+    {:noreply, schedule_check(%{state | started: started}, @serial_ports_interval_check)}
+  end
+
+  defp schedule_check(%{enabled?: false} = state, _delay), do: state
+
+  defp schedule_check(state, delay) do
+    state = cancel_timer(state)
+    %{state | timer: Process.send_after(self(), :check_serial_ports, delay)}
+  end
+
+  defp cancel_timer(%{timer: nil} = state), do: state
+
+  defp cancel_timer(%{timer: timer} = state) do
+    Process.cancel_timer(timer)
+    %{state | timer: nil}
+  end
+
+  defp stop_started(state) do
+    Enum.each(state.started, fn name ->
+      if pid = Process.whereis(name) do
+        DynamicSupervisor.terminate_child(ExNVR.Hardware.Supervisor, pid)
+      end
+    end)
+
+    %{state | started: MapSet.new()}
   end
 end

--- a/ui/lib/ex_nvr/hardware/victron.ex
+++ b/ui/lib/ex_nvr/hardware/victron.ex
@@ -1,8 +1,12 @@
 defmodule ExNVR.Hardware.Victron do
   @moduledoc """
-  Module responsible for getting data from Victron Energy products.
+  Data structure and pure parsing logic for Victron Energy products.
 
-  The data are retrieved via a serial port.
+  The data are retrieved via a serial port using the VE.Direct protocol. This
+  module holds no state: it only defines the `t:t/0` struct and the pure
+  functions used to parse the text/hex frames exchanged with the device. The
+  stateful part (opening the serial port, buffering incoming bytes, replying to
+  in-flight requests) lives in `ExNVR.Hardware.Victron.Server`.
 
   For now we support getting data for MPPT and SmartShunt, however the module
   can be extended to get information from other products such as:
@@ -13,9 +17,8 @@ defmodule ExNVR.Hardware.Victron do
     * Phoenix Charger
     * Smart BuckBoost
   """
-  require Logger
 
-  use GenServer, restart: :transient
+  import Bitwise
 
   @type operation_state ::
           :off
@@ -139,10 +142,7 @@ defmodule ExNVR.Hardware.Victron do
     h23: 0
   ]
 
-  @speed 19_200
-  @reporting_interval :timer.seconds(15)
-  @restart_interval :timer.hours(1)
-  @last_data_update_in_seconds 30
+  @battery_monitor_pids ["0xA389", "0xA38A", "0xA38B"]
 
   @alarm_reasons [
     :low_voltage,
@@ -166,168 +166,81 @@ defmodule ExNVR.Hardware.Victron do
     aes: 7
   }
 
-  @spec start_link(keyword()) :: GenServer.on_start()
-  def start_link(options) do
-    GenServer.start_link(__MODULE__, options[:port], name: options[:name])
-  end
+  @doc """
+  Whether the given product id belongs to a battery monitor (SmartShunt).
 
-  @spec write(GenServer.name(), binary()) :: :ok
-  def write(pid, data) do
-    GenServer.call(pid, {:write, data})
-  end
+  Any other product id is treated as a solar charger (MPPT).
+  """
+  @spec battery_monitor?(binary() | nil) :: boolean()
+  def battery_monitor?(pid), do: pid in @battery_monitor_pids
 
-  @spec load_output_state(GenServer.name()) :: {:ok, load_output_state()} | {:error, term()}
-  def load_output_state(pid) do
-    GenServer.call(pid, :load_output_state)
-  end
+  @doc """
+  The hex command used to query the current load output state.
+  """
+  @spec load_output_state_query() :: binary()
+  def load_output_state_query, do: ":7ABED00B6\n"
 
-  @spec set_load_output_state(GenServer.name(), load_output_state()) ::
-          {:ok, load_output_state()} | {:error, term()}
-  def set_load_output_state(pid, new_state) do
-    GenServer.call(pid, {:load_output_state, new_state})
-  end
-
-  @impl true
-  def init(serial_port) do
-    {:ok, pid} = Circuits.UART.start_link()
-
-    state = %{
-      serial_port: serial_port,
-      pid: pid,
-      data: %__MODULE__{},
-      connected: false,
-      timer: nil,
-      restart_timer: nil,
-      datetime: DateTime.utc_now(),
-      unprocessed_data: <<>>,
-      inflight_requests: []
-    }
-
-    {:ok, state, {:continue, :probe}}
-  end
-
-  @impl true
-  def handle_continue(:probe, state) do
-    with :ok <- Circuits.UART.open(state.pid, state.serial_port, uart_options()),
-         state <- %{state | connected: true},
-         true <- victron_device?(state) do
-      Circuits.UART.configure(state.pid, active: true)
-      {:ok, timer_ref} = :timer.send_interval(@reporting_interval, :report)
-      {:ok, restart_timer} = :timer.send_interval(@restart_interval, :restart)
-      {:noreply, %{state | timer: timer_ref, restart_timer: restart_timer}}
-    else
-      _other ->
-        Logger.info("#{inspect(state.serial_port)} is not a victron serial port")
-        {:stop, :normal, state}
-    end
-  catch
-    :exit, _error -> {:stop, :normal, state}
-  end
-
-  @impl true
-  def handle_call({:write, data}, _from, state) do
-    :ok = Circuits.UART.write(state.pid, data)
-    {:reply, :ok, state}
-  end
-
-  @impl true
-  def handle_call(:load_output_state, from, state) do
-    :ok = Circuits.UART.write(state.pid, ":7ABED00B6\n")
-
-    {:noreply,
-     %{state | inflight_requests: state.inflight_requests ++ [{:load_output_state, from}]}}
-  end
-
-  @impl true
-  def handle_call({:load_output_state, new_state}, from, state) do
+  @doc """
+  Build the hex command that sets the load output to `new_state`.
+  """
+  @spec set_load_output_state_command(load_output_state()) :: binary()
+  def set_load_output_state_command(new_state) do
     value = @load_output_state[new_state]
     checksum = 0xB5 - value
 
-    value = Integer.to_string(value, 16) |> String.pad_leading(2, "0") |> String.upcase()
-    checksum = Integer.to_string(checksum, 16) |> String.pad_leading(2, "0") |> String.upcase()
-    command = ":8ABED00#{value}#{checksum}\n" |> String.upcase()
+    value = value |> Integer.to_string(16) |> String.pad_leading(2, "0") |> String.upcase()
+    checksum = checksum |> Integer.to_string(16) |> String.pad_leading(2, "0") |> String.upcase()
 
-    :ok = Circuits.UART.write(state.pid, command)
-
-    {:noreply,
-     %{state | inflight_requests: state.inflight_requests ++ [{:load_output_state, from}]}}
+    String.upcase(":8ABED00#{value}#{checksum}\n")
   end
 
-  @impl true
-  def handle_info({:circuits_uart, _port, message}, state) do
-    state = do_handle_message(state, :text, state.unprocessed_data <> message)
-    state = %{state | datetime: DateTime.utc_now()}
-    {:noreply, state}
-  end
+  @doc """
+  Parse a hex response to a (get/set) load output state request.
 
-  @impl true
-  def handle_info(:report, state) do
-    time_diff = DateTime.diff(DateTime.utc_now(), state.datetime)
+  Returns:
 
-    data =
-      if is_nil(state.data.v) or time_diff >= @last_data_update_in_seconds,
-        do: nil,
-        else: state.data
+    * `:ignore` - the message is an asynchronous message and should be discarded.
+    * `{:ok, state}` - the load output `state` reported by the device.
+    * `{:error, reason}` - the response was invalid or unexpected.
+  """
+  @spec parse_load_output_response(binary()) ::
+          :ignore | {:ok, load_output_state()} | {:error, term()}
+  def parse_load_output_response(<<"A", _rest::binary>>), do: :ignore
 
-    # check if it's a smart shunt
-    if state.data.pid in ["0xA389", "0xA38A", "0xA38B"],
-      do: ExNVR.SystemStatus.set(:battery_monitor, data),
-      else: ExNVR.SystemStatus.set(:solar_charger, data)
+  def parse_load_output_response(
+        <<_::8, "ABED", flags::binary-size(2), value::binary-size(2), _checksum::binary-size(2)>>
+      ) do
+    if String.to_integer(flags, 16) == 0 do
+      look = String.to_integer(value, 16)
 
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info(:restart, state) do
-    # Sometimes the Victron stuck and send the same
-    # we restart the connection to avoid such issues
-    :ok = Circuits.UART.close(state.pid)
-    :ok = Circuits.UART.open(state.pid, state.serial_port, uart_options(true))
-
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info(_msg, state) do
-    {:noreply, state}
-  end
-
-  @impl true
-  def terminate(reason, state) do
-    if pid = state.data.pid do
-      Logger.warning("Victron process terminating due to #{inspect(reason)}")
-
-      if pid in ["0xA389", "0xA38A", "0xA38B"],
-        do: ExNVR.SystemStatus.set(:battery_monitor, nil),
-        else: ExNVR.SystemStatus.set(:solar_charger, nil)
-    end
-
-    if state.connected do
-      Circuits.UART.close(state.pid)
-    end
-
-    Circuits.UART.stop(state.pid)
-    :timer.cancel(state.timer)
-  end
-
-  defp uart_options(active \\ false), do: [active: active, speed: @speed]
-
-  defp victron_device?(state, max_attemots \\ 3)
-
-  defp victron_device?(_state, 0), do: false
-
-  # for now we do a simple test to check if the device is a victron device
-  # data should be in the format of "key\tvalue"
-  defp victron_device?(state, max_attempts) do
-    with {:ok, data} when is_binary(data) <- Circuits.UART.read(state.pid, 1000),
-         [_key, _value] <- String.split(data, "\t") do
-      true
+      {:ok, Enum.find_value(@load_output_state, fn {key, value} -> if value == look, do: key end)}
     else
-      _other -> victron_device?(state, max_attempts - 1)
+      {:error, :invalid_response}
     end
   end
 
-  defp do_handle_message(state, :hex, message) do
+  def parse_load_output_response(_message), do: {:error, :unexpected_response}
+
+  @doc """
+  Parse the `buffer` received from the device, updating `data` accordingly.
+
+  Text frames (`key\\tvalue`) update the `data` struct while hex frames are
+  collected and returned so the caller can match them to in-flight requests.
+
+  Returns `{updated_data, hex_messages, remaining_buffer}` where:
+
+    * `updated_data` - the `data` struct updated with every complete text frame.
+    * `hex_messages` - the complete hex frames encountered, in order.
+    * `remaining_buffer` - the trailing incomplete frame, to be prepended to the
+      next chunk of data.
+  """
+  @spec parse(t(), binary()) :: {t(), [binary()], binary()}
+  def parse(%__MODULE__{} = data, buffer) do
+    {data, hex, rest} = do_parse(data, [], :text, buffer)
+    {data, Enum.reverse(hex), rest}
+  end
+
+  defp do_parse(data, hex, :hex, message) do
     case String.split(message, "\n", parts: 2) do
       [message, rest] ->
         {mode, rest} =
@@ -335,22 +248,20 @@ defmodule ExNVR.Hardware.Victron do
             do: {:hex, binary_part(rest, 1, byte_size(rest) - 1)},
             else: {:text, rest}
 
-        state
-        |> parse_hex_message(message)
-        |> do_handle_message(mode, rest)
+        do_parse(data, [message | hex], mode, rest)
 
       [incomplete] ->
-        %{state | unprocessed_data: incomplete}
+        {data, hex, incomplete}
     end
   end
 
-  defp do_handle_message(%{data: %__MODULE__{} = data} = state, :text, message) do
+  defp do_parse(data, hex, :text, message) do
     case String.split(message, "\r\n", parts: 2) do
       [line, rest] ->
-        # check if there'a any hex message
-        {line, hex} =
+        # check if there's any hex message
+        {line, hex_frame} =
           case String.split(line, ":", parts: 2) do
-            [line, hex] -> {line, hex}
+            [line, hex_frame] -> {line, hex_frame}
             _ -> {line, nil}
           end
 
@@ -360,49 +271,13 @@ defmodule ExNVR.Hardware.Victron do
             _other -> data
           end
 
-        state = %{state | data: data}
-
-        if hex,
-          do: do_handle_message(state, :hex, hex <> rest),
-          else: do_handle_message(state, :text, rest)
+        if hex_frame,
+          do: do_parse(data, hex, :hex, hex_frame <> rest),
+          else: do_parse(data, hex, :text, rest)
 
       [incomplete] ->
-        %{state | unprocessed_data: incomplete}
+        {data, hex, incomplete}
     end
-  end
-
-  defp parse_hex_message(state, <<"A", _rest::binary>>) do
-    Logger.debug("[Victron] hex: ignore asynchronous message")
-    state
-  end
-
-  defp parse_hex_message(%{inflight_requests: []} = state, message) do
-    Logger.debug("Victron hex message received: #{inspect(message, limit: :infinity)}")
-    state
-  end
-
-  defp parse_hex_message(%{inflight_requests: [{_op, requester} | rest]} = state, message) do
-    Logger.debug("Received hex response: #{inspect(message, limit: :infinity)}")
-
-    case message do
-      <<_::8, "ABED", flags::binary-size(2), value::binary-size(2), _checksum::binary-size(2)>> ->
-        reply =
-          if String.to_integer(flags, 16) == 0 do
-            look = String.to_integer(value, 16)
-
-            {:ok,
-             Enum.find_value(@load_output_state, fn {key, value} -> if value == look, do: key end)}
-          else
-            {:error, :invalid_response}
-          end
-
-        GenServer.reply(requester, reply)
-
-      _ ->
-        GenServer.reply(requester, {:error, :unexpected_response})
-    end
-
-    %{state | inflight_requests: rest}
   end
 
   defp do_handle_value(data, "pid", value), do: %{data | pid: value}
@@ -436,7 +311,11 @@ defmodule ExNVR.Hardware.Victron do
   defp do_handle_value(data, "cs", value),
     do: %{data | cs: String.to_integer(value) |> operation_state()}
 
-  defp do_handle_value(data, key, value) when key in ["relay", "alarm", "load"] do
+  defp do_handle_value(data, "relay", value) do
+    %{data | relay_state: value |> String.downcase() |> String.to_existing_atom()}
+  end
+
+  defp do_handle_value(data, key, value) when key in ["alarm", "load"] do
     Map.put(data, String.to_atom(key), String.downcase(value) |> String.to_existing_atom())
   end
 
@@ -463,9 +342,9 @@ defmodule ExNVR.Hardware.Victron do
 
     @alarm_reasons
     |> Enum.reduce({[], value}, fn alarm, {alarms, value} ->
-      case Bitwise.band(value, 1) do
-        0 -> {alarms, Bitwise.bsr(value, 1)}
-        1 -> {[alarm | alarms], Bitwise.bsr(value, 1)}
+      case band(value, 1) do
+        0 -> {alarms, bsr(value, 1)}
+        1 -> {[alarm | alarms], bsr(value, 1)}
       end
     end)
     |> elem(0)

--- a/ui/lib/ex_nvr/hardware/victron/server.ex
+++ b/ui/lib/ex_nvr/hardware/victron/server.ex
@@ -1,0 +1,203 @@
+defmodule ExNVR.Hardware.Victron.Server do
+  @moduledoc """
+  GenServer responsible for getting data from Victron Energy products.
+
+  It owns the serial port connection and all mutable state (incoming byte
+  buffer, in-flight requests, timers). The actual parsing of the VE.Direct
+  frames is delegated to the stateless `ExNVR.Hardware.Victron` module.
+  """
+
+  use GenServer, restart: :transient
+
+  require Logger
+
+  alias ExNVR.Hardware.Victron
+
+  @speed 19_200
+  @reporting_interval :timer.seconds(15)
+  @restart_interval :timer.hours(1)
+  @last_data_update_in_seconds 30
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(options) do
+    GenServer.start_link(__MODULE__, options[:port], name: options[:name])
+  end
+
+  @spec write(GenServer.name(), binary()) :: :ok
+  def write(pid, data) do
+    GenServer.call(pid, {:write, data})
+  end
+
+  @spec load_output_state(GenServer.name()) ::
+          {:ok, Victron.load_output_state()} | {:error, term()}
+  def load_output_state(pid) do
+    GenServer.call(pid, :load_output_state)
+  end
+
+  @spec set_load_output_state(GenServer.name(), Victron.load_output_state()) ::
+          {:ok, Victron.load_output_state()} | {:error, term()}
+  def set_load_output_state(pid, new_state) do
+    GenServer.call(pid, {:load_output_state, new_state})
+  end
+
+  @impl true
+  def init(serial_port) do
+    {:ok, pid} = Circuits.UART.start_link()
+
+    state = %{
+      serial_port: serial_port,
+      pid: pid,
+      data: %Victron{},
+      connected: false,
+      timer: nil,
+      restart_timer: nil,
+      datetime: DateTime.utc_now(),
+      unprocessed_data: <<>>,
+      inflight_requests: []
+    }
+
+    {:ok, state, {:continue, :probe}}
+  end
+
+  @impl true
+  def handle_continue(:probe, state) do
+    with :ok <- Circuits.UART.open(state.pid, state.serial_port, uart_options()),
+         state <- %{state | connected: true},
+         true <- victron_device?(state) do
+      Circuits.UART.configure(state.pid, active: true)
+      {:ok, timer_ref} = :timer.send_interval(@reporting_interval, :report)
+      {:ok, restart_timer} = :timer.send_interval(@restart_interval, :restart)
+      {:noreply, %{state | timer: timer_ref, restart_timer: restart_timer}}
+    else
+      _other ->
+        Logger.info("#{inspect(state.serial_port)} is not a victron serial port")
+        {:stop, :normal, state}
+    end
+  catch
+    :exit, _error -> {:stop, :normal, state}
+  end
+
+  @impl true
+  def handle_call({:write, data}, _from, state) do
+    :ok = Circuits.UART.write(state.pid, data)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(:load_output_state, from, state) do
+    :ok = Circuits.UART.write(state.pid, Victron.load_output_state_query())
+
+    {:noreply,
+     %{state | inflight_requests: state.inflight_requests ++ [{:load_output_state, from}]}}
+  end
+
+  @impl true
+  def handle_call({:load_output_state, new_state}, from, state) do
+    :ok = Circuits.UART.write(state.pid, Victron.set_load_output_state_command(new_state))
+
+    {:noreply,
+     %{state | inflight_requests: state.inflight_requests ++ [{:load_output_state, from}]}}
+  end
+
+  @impl true
+  def handle_info({:circuits_uart, _port, message}, state) do
+    {data, hex_messages, unprocessed_data} =
+      Victron.parse(state.data, state.unprocessed_data <> message)
+
+    state = %{state | data: data, unprocessed_data: unprocessed_data}
+    state = reply_to_hex_messages(state, hex_messages)
+    state = %{state | datetime: DateTime.utc_now()}
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:report, state) do
+    time_diff = DateTime.diff(DateTime.utc_now(), state.datetime)
+
+    data =
+      if is_nil(state.data.v) or time_diff >= @last_data_update_in_seconds,
+        do: nil,
+        else: state.data
+
+    if Victron.battery_monitor?(state.data.pid),
+      do: ExNVR.SystemStatus.set(:battery_monitor, data),
+      else: ExNVR.SystemStatus.set(:solar_charger, data)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:restart, state) do
+    # Sometimes the Victron stuck and send the same data
+    # we restart the connection to avoid such issues
+    :ok = Circuits.UART.close(state.pid)
+    :ok = Circuits.UART.open(state.pid, state.serial_port, uart_options(true))
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(reason, state) do
+    if pid = state.data.pid do
+      Logger.warning("Victron process terminating due to #{inspect(reason)}")
+
+      if Victron.battery_monitor?(pid),
+        do: ExNVR.SystemStatus.set(:battery_monitor, nil),
+        else: ExNVR.SystemStatus.set(:solar_charger, nil)
+    end
+
+    if state.connected do
+      Circuits.UART.close(state.pid)
+    end
+
+    Circuits.UART.stop(state.pid)
+    :timer.cancel(state.timer)
+  end
+
+  # replies to in-flight requests as their hex responses come in, in order
+  defp reply_to_hex_messages(state, []), do: state
+
+  defp reply_to_hex_messages(state, [message | rest]) do
+    state =
+      case Victron.parse_load_output_response(message) do
+        :ignore ->
+          Logger.debug("[Victron] hex: ignore asynchronous message")
+          state
+
+        reply ->
+          case state.inflight_requests do
+            [{_op, requester} | remaining] ->
+              GenServer.reply(requester, reply)
+              %{state | inflight_requests: remaining}
+
+            [] ->
+              Logger.debug("Victron hex message received: #{inspect(message, limit: :infinity)}")
+              state
+          end
+      end
+
+    reply_to_hex_messages(state, rest)
+  end
+
+  defp uart_options(active \\ false), do: [active: active, speed: @speed]
+
+  defp victron_device?(state, max_attempts \\ 3)
+
+  defp victron_device?(_state, 0), do: false
+
+  # for now we do a simple test to check if the device is a victron device
+  # data should be in the format of "key\tvalue"
+  defp victron_device?(state, max_attempts) do
+    with {:ok, data} when is_binary(data) <- Circuits.UART.read(state.pid, 1000),
+         [_key, _value] <- String.split(data, "\t") do
+      true
+    else
+      _other -> victron_device?(state, max_attempts - 1)
+    end
+  end
+end

--- a/ui/lib/ex_nvr_web/channels/device_room_channel.ex
+++ b/ui/lib/ex_nvr_web/channels/device_room_channel.ex
@@ -33,9 +33,6 @@ defmodule ExNVRWeb.DeviceRoomChannel do
     {:noreply, socket}
   end
 
-  # A misbehaving or malicious client could send a payload that is not valid
-  # JSON. Decoding defensively keeps that from crashing the channel (and forcing
-  # the whole session to re-join) over a single bad frame.
   defp forward_decoded(socket, type, payload) do
     case Jason.decode(payload) do
       {:ok, data} ->

--- a/ui/test/ex_nvr/hardware/victron_test.exs
+++ b/ui/test/ex_nvr/hardware/victron_test.exs
@@ -1,0 +1,142 @@
+defmodule ExNVR.Hardware.VictronTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias ExNVR.Hardware.Victron
+
+  describe "battery_monitor?/1" do
+    test "true for known SmartShunt product ids" do
+      for pid <- ["0xA389", "0xA38A", "0xA38B"] do
+        assert Victron.battery_monitor?(pid)
+      end
+    end
+
+    test "false for solar chargers and nil" do
+      refute Victron.battery_monitor?("0xA053")
+      refute Victron.battery_monitor?(nil)
+    end
+  end
+
+  describe "load_output_state_query/0" do
+    test "returns the fixed query command" do
+      assert Victron.load_output_state_query() == ":7ABED00B6\n"
+    end
+  end
+
+  describe "set_load_output_state_command/1" do
+    test "encodes value and checksum for :on" do
+      # value = 4 -> "04", checksum = 0xB5 - 4 = 0xB1 -> "B1"
+      assert Victron.set_load_output_state_command(:on) == ":8ABED0004B1\n"
+    end
+
+    test "encodes value and checksum for :off" do
+      # value = 0 -> "00", checksum = 0xB5 -> "B5"
+      assert Victron.set_load_output_state_command(:off) == ":8ABED0000B5\n"
+    end
+
+    test "encodes value and checksum for :aes" do
+      # value = 7 -> "07", checksum = 0xB5 - 7 = 0xAE -> "AE"
+      assert Victron.set_load_output_state_command(:aes) == ":8ABED0007AE\n"
+    end
+  end
+
+  describe "parse_load_output_response/1" do
+    test "ignores asynchronous messages" do
+      assert Victron.parse_load_output_response("A123456789") == :ignore
+    end
+
+    test "decodes a successful response into the load output state" do
+      # command byte + "ABED" + flags "00" + value "04" (:on) + checksum
+      assert Victron.parse_load_output_response("7ABED0004B1") == {:ok, :on}
+      assert Victron.parse_load_output_response("7ABED0000B5") == {:ok, :off}
+    end
+
+    test "returns invalid_response when flags are non-zero" do
+      assert Victron.parse_load_output_response("7ABED0104B1") == {:error, :invalid_response}
+    end
+
+    test "returns unexpected_response for a malformed message" do
+      assert Victron.parse_load_output_response("garbage") == {:error, :unexpected_response}
+    end
+  end
+
+  describe "parse/2 text frames" do
+    test "parses key/value text frames into the struct" do
+      buffer = "PID\t0xA053\r\nV\t25000\r\nI\t1600\r\nSOC\t950\r\n"
+
+      assert {data, [], ""} = Victron.parse(%Victron{}, buffer)
+      assert data.pid == "0xA053"
+      assert data.v == 25_000
+      assert data.i == 1_600
+      assert data.soc == 950
+    end
+
+    test "keys are case-insensitive" do
+      assert {data, [], ""} = Victron.parse(%Victron{}, "v\t42\r\n")
+      assert data.v == 42
+    end
+
+    test "maps the operation state (CS)" do
+      assert {%{cs: :bulk}, [], ""} = Victron.parse(%Victron{}, "CS\t3\r\n")
+      assert {%{cs: :float}, [], ""} = Victron.parse(%Victron{}, "CS\t5\r\n")
+      assert {%{cs: :unknown}, [], ""} = Victron.parse(%Victron{}, "CS\t99\r\n")
+    end
+
+    test "decodes the off reason from hex" do
+      assert {%{off_reason: 5}, [], ""} = Victron.parse(%Victron{}, "OR\t0x00000005\r\n")
+    end
+
+    test "decodes alarm/load into atoms" do
+      assert {data, [], ""} = Victron.parse(%Victron{}, "LOAD\tON\r\nALARM\tOFF\r\n")
+      assert data.load == :on
+      assert data.alarm == :off
+    end
+
+    test "decodes relay into the relay_state field" do
+      assert {data, [], ""} = Victron.parse(%Victron{}, "RELAY\tON\r\n")
+      assert data.relay_state == :on
+    end
+
+    test "decodes alarm reasons from the bitmask" do
+      # bit 0 (low_voltage) + bit 2 (low_soc) = 5
+      assert {data, [], ""} = Victron.parse(%Victron{}, "AR\t5\r\n")
+      assert Enum.sort(data.alarm_reasons) == Enum.sort([:low_voltage, :low_soc])
+    end
+
+    test "ignores unknown keys" do
+      assert {%Victron{}, [], ""} = Victron.parse(%Victron{}, "UNKNOWN\tvalue\r\n")
+    end
+  end
+
+  describe "parse/2 buffering" do
+    test "returns the trailing incomplete frame as remaining buffer" do
+      assert {data, [], "I\t16"} = Victron.parse(%Victron{}, "V\t25000\r\nI\t16")
+      assert data.v == 25_000
+    end
+
+    test "resuming with the remaining buffer yields the full value" do
+      {data, [], rest} = Victron.parse(%Victron{}, "V\t25000\r\nI\t16")
+      assert {data, [], ""} = Victron.parse(data, rest <> "00\r\n")
+      assert data.i == 1_600
+    end
+  end
+
+  describe "parse/2 hex frames" do
+    test "collects a hex frame embedded in the stream, buffering trailing text" do
+      buffer = "V\t25000\r\n:7ABED0004B1\nI\t1600\r\n"
+
+      # the hex frame's terminator consumes the line delimiter, so the text that
+      # follows it stays buffered until the next \r\n arrives.
+      assert {data, ["7ABED0004B1"], "I\t1600"} = Victron.parse(%Victron{}, buffer)
+      assert data.v == 25_000
+    end
+
+    test "collects multiple consecutive hex frames in order" do
+      buffer = ":7ABED0004B1\n:7ABED0000B5\nV\t1\r\n"
+
+      assert {_data, ["7ABED0004B1", "7ABED0000B5"], "V\t1"} =
+               Victron.parse(%Victron{}, buffer)
+    end
+  end
+end


### PR DESCRIPTION
Closes #943 
In this PR:

- Added a config to disable/enable serial port probing to detect victron devices (this config can be provided at compile or runtime time and it defaults to false)
- Refactor the victron code (separating the logic from the state and adding unit tests)

In the next PR, we'll add another config to `nerves_fw` to enable/disable victron probing using the power type of the kit.