### PR TITLE
nerves: add power type to system settings

### DIFF
--- a/nerves_fw/lib/nerves_fw/application.ex
+++ b/nerves_fw/lib/nerves_fw/application.ex
@@ -11,12 +11,18 @@ defmodule ExNVR.Nerves.Application do
   def start(_type, _args) do
     opts = [strategy: :one_for_one, name: ExNVR.Nerves.Supervisor]
 
+    children = [{Phoenix.PubSub, name: ExNVR.Nerves.PubSub}]
+
     children =
-      [{Phoenix.PubSub, name: ExNVR.Nerves.PubSub}, {ExNVR.Nerves.SystemSettings, []}] ++
-        children(target())
+      if Mix.env() != :test do
+        children ++ [{ExNVR.Nerves.SystemSettings, []}]
+      else
+        children
+      end
+
+    children = children ++ children(target())
 
     ExNVR.Release.migrate()
-
     Supervisor.start_link(children, opts)
   end
 

--- a/nerves_fw/lib/nerves_fw/giraffe/init.ex
+++ b/nerves_fw/lib/nerves_fw/giraffe/init.ex
@@ -15,29 +15,33 @@ defmodule ExNVR.Nerves.Giraffe.Init do
   alias ExNVR.Nerves.GPIO
   alias ExNVR.Nerves.{SystemSettings, SystemStatus}
 
+  @ups_config %{
+    enabled: true,
+    ac_pin: "GPIO4",
+    battery_pin: "GPIO8",
+    ac_pin_default: 1,
+    battery_pin_default: 1,
+    trigger_after: 0,
+    low_battery_action: :power_off,
+    ac_failure_action: :nothing
+  }
+
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, nil)
   end
 
+  @doc """
+  Enable UPS monitoring when the power type is `:mains`, disable it otherwise.
+  """
+  @spec set_ups(atom()) :: :ok | :error
+  def set_ups(:mains), do: update_ups(@ups_config)
+  def set_ups(_power_type), do: update_ups(%{enabled: false})
+
   @impl true
   def init(_options) do
-    res =
-      SystemSettings.update(%{
-        ups: %{
-          enabled: true,
-          ac_pin: "GPIO4",
-          battery_pin: "GPIO8",
-          ac_pin_default: 1,
-          battery_pin_default: 1,
-          trigger_after: 0,
-          low_battery_action: :power_off,
-          ac_failure_action: :nothing
-        }
-      })
-
-    with {:error, _} <- res do
-      Logger.error("[Init] failed to update ups settings")
-    end
+    SystemSettings.get_settings()
+    |> Map.fetch!(:power_type)
+    |> set_ups()
 
     {:ok, nil, {:continue, :init}}
   end
@@ -66,4 +70,15 @@ defmodule ExNVR.Nerves.Giraffe.Init do
 
   defp generator_state(0), do: :on
   defp generator_state(_), do: :off
+
+  defp update_ups(params) do
+    case SystemSettings.update(%{ups: params}) do
+      {:ok, _settings} ->
+        :ok
+
+      {:error, _reason} ->
+        Logger.error("[Init] failed to update ups settings")
+        :error
+    end
+  end
 end

--- a/nerves_fw/lib/nerves_fw/remote_config_handler.ex
+++ b/nerves_fw/lib/nerves_fw/remote_config_handler.ex
@@ -4,8 +4,8 @@ defmodule ExNVR.Nerves.RemoteConfigHandler do
   require Logger
 
   alias ExNVR.{Hardware, Model}
-  alias ExNVR.Nerves.Giraffe.Init
   alias ExNVR.Nerves.{Application, RUT, SystemSettings}
+  alias ExNVR.Nerves.Giraffe.Init
 
   def handle_message("config", config) do
     Logger.info("[RemoteConfigHandler] handle new incoming config event")

--- a/nerves_fw/lib/nerves_fw/remote_config_handler.ex
+++ b/nerves_fw/lib/nerves_fw/remote_config_handler.ex
@@ -3,30 +3,40 @@ defmodule ExNVR.Nerves.RemoteConfigHandler do
 
   require Logger
 
-  alias ExNVR.Model
-  alias ExNVR.Nerves.{RUT, SystemSettings}
+  alias ExNVR.{Hardware, Model}
+  alias ExNVR.Nerves.Giraffe.Init
+  alias ExNVR.Nerves.{Application, RUT, SystemSettings}
 
   def handle_message("config", config) do
     Logger.info("[RemoteConfigHandler] handle new incoming config event")
-
     settings = SystemSettings.get_settings()
+    do_handle_message(settings.configured, settings, config)
+  end
 
-    # ignore if the kit is not yet configured
-    if settings.configured do
-      with {:ok, _new_settings} <- SystemSettings.update_router_settings(config["router"] || %{}),
-           {:ok, new_settings} <-
-             SystemSettings.update_power_schedule_settings(config["power_schedule"] || %{}) do
-        # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+  defp do_handle_message(false, _settings, _config), do: :ok
+
+  defp do_handle_message(_configured, settings, config) do
+    params = %{
+      router: config["router"] || %{},
+      power_schedule: config["power_schedule"] || %{},
+      power_type: config["power_type"]
+    }
+
+    case SystemSettings.update(params) do
+      {:ok, new_settings} ->
         if power_schedule_updated?(settings.power_schedule, new_settings.power_schedule) do
           Logger.info("[RemoteConfigHandler] Updating router schedule")
           update_router_schedule(new_settings.power_schedule.schedule)
         end
-      else
-        {:error, reason} ->
-          Logger.error(
-            "[RemoteConfigHandler] Failed to update router or power schedule settings: #{inspect(reason)}"
-          )
-      end
+
+        if settings.power_type != new_settings.power_type do
+          handle_power_type_update(new_settings.power_type)
+        end
+
+      {:error, reason} ->
+        Logger.error(
+          "[RemoteConfigHandler] Failed to update router or power schedule settings: #{inspect(reason)}"
+        )
     end
   end
 
@@ -58,5 +68,17 @@ defmodule ExNVR.Nerves.RemoteConfigHandler do
 
       {day, intervals}
     end)
+  end
+
+  defp handle_power_type_update(power_type) do
+    # Enable/disable victron data gathering
+    if power_type in [:solar, :generator],
+      do: Hardware.SerialPortChecker.enable(),
+      else: Hardware.SerialPortChecker.disable()
+
+    # Enable/disable ups for giraffe
+    if Application.target() == :giraffe do
+      Init.set_ups(power_type)
+    end
   end
 end

--- a/nerves_fw/lib/nerves_fw/system_settings.ex
+++ b/nerves_fw/lib/nerves_fw/system_settings.ex
@@ -19,11 +19,14 @@ defmodule ExNVR.Nerves.SystemSettings do
 
     import Ecto.Changeset
 
+    @power_values ~w(mains solar generator other)a
+
     @primary_key false
     @derive JSON.Encoder
     embedded_schema do
       field :kit_serial, :string
       field :configured, :boolean, default: false
+      field :power_type, Ecto.Enum, values: @power_values, default: :other
 
       embeds_one :power_schedule, PowerSchedule, primary_key: false, on_replace: :update do
         @derive JSON.Encoder
@@ -69,7 +72,7 @@ defmodule ExNVR.Nerves.SystemSettings do
 
     def changeset(settings \\ %__MODULE__{}, params) do
       settings
-      |> cast(params, [:kit_serial, :configured])
+      |> cast(params, [:kit_serial, :configured, :power_type])
       |> cast_embed(:power_schedule, with: &power_schedule_changeset/2)
       |> cast_embed(:router, with: &router_changeset/2)
       |> cast_embed(:ups, with: &ups_changeset/2)

--- a/nerves_fw/lib/nerves_fw/system_settings.ex
+++ b/nerves_fw/lib/nerves_fw/system_settings.ex
@@ -166,8 +166,8 @@ defmodule ExNVR.Nerves.SystemSettings do
   end
 
   @impl true
-  def init(_opts) do
-    path = settings_path()
+  def init(opts) do
+    path = settings_path(opts[:path])
 
     settings =
       with {:ok, json_data} <- File.read(path),
@@ -234,8 +234,8 @@ defmodule ExNVR.Nerves.SystemSettings do
     end
   end
 
-  defp settings_path do
-    Application.get_env(:ex_nvr_fw, :system_settings_path, @default_path)
+  defp settings_path(path) do
+    Application.get_env(:ex_nvr_fw, :system_settings_path, path || @default_path)
   end
 
   defp put_default_values(settings) do

--- a/nerves_fw/test/ex_nvr/remote_config_handler_test.exs
+++ b/nerves_fw/test/ex_nvr/remote_config_handler_test.exs
@@ -1,0 +1,111 @@
+defmodule ExNVR.Nerves.RemoteConfigHandlerTest do
+  @moduledoc false
+  use ExNVR.DataCase, async: false
+
+  import Mimic
+
+  alias ExNVR.Hardware
+  alias ExNVR.Nerves.Giraffe.Init
+  alias ExNVR.Nerves.{RemoteConfigHandler, RUT, SystemSettings}
+
+  @moduletag :tmp_dir
+  @moduletag capture_log: true
+
+  setup :set_mimic_global
+  setup :verify_on_exit!
+
+  setup_all do
+    Mimic.copy(RUT)
+    Mimic.copy(Init)
+    Mimic.copy(Hardware.SerialPortChecker)
+    :ok
+  end
+
+  setup %{tmp_dir: tmp_dir} do
+    start_supervised!({SystemSettings, [path: Path.join(tmp_dir, "settings.json")]})
+    on_exit(fn -> Application.put_env(:ex_nvr_fw, :target, :host) end)
+    :ok
+  end
+
+  describe "handle_message/2" do
+    test "ignores incoming config when the kit is not configured" do
+      reject(&RUT.set_scheduler/1)
+      reject(&Hardware.SerialPortChecker.enable/0)
+      reject(&Hardware.SerialPortChecker.disable/0)
+      reject(&Init.set_ups/1)
+
+      assert :ok = RemoteConfigHandler.handle_message("config", %{"power_type" => "solar"})
+
+      assert SystemSettings.get_settings().power_type == :other
+    end
+
+    test "updates the router schedule when the power schedule changes" do
+      mark_configured()
+      expect(RUT, :set_scheduler, fn _schedule -> :ok end)
+
+      config = %{"power_schedule" => %{"schedule" => %{"1" => ["10:00-15:00"]}}}
+      RemoteConfigHandler.handle_message("config", config)
+
+      assert SystemSettings.get_settings().power_schedule.schedule == %{"1" => ["10:00-15:00"]}
+    end
+
+    test "does not update the router schedule when the power schedule is unchanged" do
+      mark_configured()
+      reject(&RUT.set_scheduler/1)
+
+      RemoteConfigHandler.handle_message("config", %{"router" => %{"username" => "user"}})
+
+      assert SystemSettings.get_settings().router.username == "user"
+    end
+
+    test "enables serial port checker and updates ups when power type is solar on giraffe" do
+      mark_configured()
+      Application.put_env(:ex_nvr_fw, :target, :giraffe)
+
+      expect(Hardware.SerialPortChecker, :enable, fn -> :ok end)
+      expect(Init, :set_ups, fn :solar -> :ok end)
+
+      RemoteConfigHandler.handle_message("config", %{"power_type" => "solar"})
+      assert SystemSettings.get_settings().power_type == :solar
+    end
+
+    test "disables serial port checker and updates ups when power type is mains on giraffe" do
+      mark_configured()
+      Application.put_env(:ex_nvr_fw, :target, :giraffe)
+
+      expect(Hardware.SerialPortChecker, :disable, fn -> :ok end)
+      expect(Init, :set_ups, fn :mains -> :ok end)
+
+      RemoteConfigHandler.handle_message("config", %{"power_type" => "mains"})
+
+      assert SystemSettings.get_settings().power_type == :mains
+    end
+
+    test "does not update ups on non-giraffe targets" do
+      mark_configured()
+
+      expect(Hardware.SerialPortChecker, :enable, fn -> :ok end)
+      reject(&Init.set_ups/1)
+
+      RemoteConfigHandler.handle_message("config", %{"power_type" => "generator"})
+
+      assert SystemSettings.get_settings().power_type == :generator
+    end
+
+    test "does not run power type handlers when the power type is unchanged" do
+      mark_configured()
+
+      reject(&Hardware.SerialPortChecker.enable/0)
+      reject(&Hardware.SerialPortChecker.disable/0)
+      reject(&Init.set_ups/1)
+
+      RemoteConfigHandler.handle_message("config", %{"power_type" => "other"})
+
+      assert SystemSettings.get_settings().power_type == :other
+    end
+  end
+
+  defp mark_configured do
+    {:ok, _settings} = SystemSettings.update(%{configured: true})
+  end
+end

--- a/nerves_fw/test/ex_nvr/system_settings_test.exs
+++ b/nerves_fw/test/ex_nvr/system_settings_test.exs
@@ -31,7 +31,7 @@ defmodule ExNVR.SystemSettingsTest do
   end
 
   test "system settings" do
-    assert SystemSettings.get_settings == @default_settings
+    assert SystemSettings.get_settings() == @default_settings
 
     assert {:ok, settings} =
              SystemSettings.update_router_settings(%{
@@ -78,7 +78,7 @@ defmodule ExNVR.SystemSettingsTest do
   end
 
   test "ignore wrong settings" do
-    assert SystemSettings.get_settings == @default_settings
+    assert SystemSettings.get_settings() == @default_settings
 
     assert {:error, _changeset} =
              SystemSettings.update_router_settings(%{

--- a/nerves_fw/test/ex_nvr/system_settings_test.exs
+++ b/nerves_fw/test/ex_nvr/system_settings_test.exs
@@ -26,16 +26,15 @@ defmodule ExNVR.SystemSettingsTest do
   }
 
   setup %{tmp_dir: tmp_dir} do
-    Application.put_env(:ex_nvr_fw, :system_settings_path, Path.join(tmp_dir, "settings.json"))
+    start_supervised!({SystemSettings, [path: Path.join(tmp_dir, "settings.json")]})
+    :ok
   end
 
   test "system settings" do
-    assert pid = start_link_supervised!({SystemSettings, [name: SystemSettingsTest]})
-
-    assert SystemSettings.get_settings(pid) == @default_settings
+    assert SystemSettings.get_settings == @default_settings
 
     assert {:ok, settings} =
-             SystemSettings.update_router_settings(pid, %{
+             SystemSettings.update_router_settings(%{
                "username" => "user",
                "password" => "pass"
              })
@@ -46,7 +45,7 @@ defmodule ExNVR.SystemSettingsTest do
            }
 
     assert {:ok, settings} =
-             SystemSettings.update_power_schedule_settings(pid, %{
+             SystemSettings.update_power_schedule_settings(%{
                schedule: %{"1" => ["10:00-15:00"]},
                action: "nothing"
              })
@@ -62,7 +61,7 @@ defmodule ExNVR.SystemSettingsTest do
            }
 
     assert {:ok, settings} =
-             SystemSettings.update_power_schedule_settings(pid, %{timezone: "Africa/Algiers"})
+             SystemSettings.update_power_schedule_settings(%{timezone: "Africa/Algiers"})
 
     assert settings.power_schedule ==
              %SystemSettings.State.PowerSchedule{
@@ -72,24 +71,22 @@ defmodule ExNVR.SystemSettingsTest do
              }
 
     assert {:ok, settings} =
-             SystemSettings.update(pid, %{"kit_serial" => "my_kit", "configured" => "true"})
+             SystemSettings.update(%{"kit_serial" => "my_kit", "configured" => "true"})
 
     assert settings.kit_serial == "my_kit"
     assert settings.configured
   end
 
   test "ignore wrong settings" do
-    assert pid = start_link_supervised!({SystemSettings, [name: SystemStatusTest]})
-
-    assert SystemSettings.get_settings(pid) == @default_settings
+    assert SystemSettings.get_settings == @default_settings
 
     assert {:error, _changeset} =
-             SystemSettings.update_router_settings(pid, %{
+             SystemSettings.update_router_settings(%{
                "username" => 15,
                "passwor" => "pass"
              })
 
-    assert SystemSettings.get_settings(pid).router == %SystemSettings.State.Router{
+    assert SystemSettings.get_settings().router == %SystemSettings.State.Router{
              username: nil,
              password: nil
            }

--- a/nerves_fw/test/ex_nvr/ups_test.exs
+++ b/nerves_fw/test/ex_nvr/ups_test.exs
@@ -18,13 +18,8 @@ defmodule ExNVR.Nerves.Monitoring.UPSTest do
   end
 
   setup %{tmp_dir: tmp_dir} do
-    Application.put_env(:ex_nvr_fw, :system_settings_path, Path.join(tmp_dir, "settings.json"))
-    # make system settings process pick the path
-    # in the config above
-    Process.exit(Process.whereis(SystemSettings), :kill)
-
+    start_supervised!({SystemSettings, [path: Path.join(tmp_dir, "settings.json")]})
     expect(ExNVR.Nerves.DiskMounter, :mount, 3, fn -> :ok end)
-
     :ok
   end
 


### PR DESCRIPTION
close #926 

Add a power type field to system settings, this field is populated by the remote connection (in our case, it's Evercam Media server). The power type field is used to enable/disable some features:

- If the kit is a `giraffe`: UPS is enabled for `mains` and disabled for others
- For all kits: victron stats are enabled for `solar` and `generator` and disabled for the others.