### PR TITLE
Get router's modem temperature

### DIFF
--- a/nerves_fw/lib/nerves_fw/giraffe/fan.ex
+++ b/nerves_fw/lib/nerves_fw/giraffe/fan.ex
@@ -36,10 +36,10 @@ defmodule ExNVR.Nerves.Giraffe.Fan do
   @default_lookup_table [
     {30, 20},
     {40, 30},
-    {50, 45},
-    {60, 65},
-    {70, 85},
-    {80, 100}
+    {45, 45},
+    {50, 65},
+    {60, 85},
+    {70, 100}
   ]
 
   @type bus :: I2C.bus()

--- a/nerves_fw/lib/nerves_fw/giraffe/fan_controller.ex
+++ b/nerves_fw/lib/nerves_fw/giraffe/fan_controller.ex
@@ -148,7 +148,7 @@ defmodule ExNVR.Nerves.Giraffe.FanController do
     {:reply, Fan.set_lookup_table(state.bus, table), state}
   end
 
-  defp get_router_temp() do
+  defp get_router_temp do
     case RUT.modems_status() do
       {:ok, [%{temperature: temp} | _]} when is_number(temp) -> temp
       _ -> 0

--- a/nerves_fw/lib/nerves_fw/giraffe/fan_controller.ex
+++ b/nerves_fw/lib/nerves_fw/giraffe/fan_controller.ex
@@ -8,6 +8,7 @@ defmodule ExNVR.Nerves.Giraffe.FanController do
   require Logger
 
   alias ExNVR.Nerves.Giraffe.Fan
+  alias ExNVR.Nerves.RUT
 
   @sync_interval to_timeout(second: 30)
 
@@ -93,7 +94,13 @@ defmodule ExNVR.Nerves.Giraffe.FanController do
   @impl true
   def handle_continue(:sync_forced_temp, state) do
     with {:ok, temp} <- Fan.internal_temperature(state.bus),
-         :ok <- Fan.set_forced_external_temp(state.bus, temp) do
+         router_temp <- get_router_temp(),
+         final_temp <- if(router_temp > 0, do: trunc((temp + router_temp) / 2), else: temp),
+         :ok <- Fan.set_forced_external_temp(state.bus, final_temp) do
+      Logger.info(
+        "[FanController] syncing forced temperature: internal=#{temp}, router=#{router_temp}, final=#{final_temp}"
+      )
+
       :ok
     else
       {:error, reason} ->
@@ -139,5 +146,14 @@ defmodule ExNVR.Nerves.Giraffe.FanController do
   @impl true
   def handle_call({:set_lookup_table, table}, _from, state) do
     {:reply, Fan.set_lookup_table(state.bus, table), state}
+  end
+
+  defp get_router_temp() do
+    case RUT.modems_status() do
+      {:ok, [%{temperature: temp} | _]} when is_number(temp) -> temp
+      _ -> 0
+    end
+  catch
+    _error, _reason -> 0
   end
 end

--- a/nerves_fw/lib/nerves_fw/rut.ex
+++ b/nerves_fw/lib/nerves_fw/rut.ex
@@ -3,7 +3,7 @@ defmodule ExNVR.Nerves.RUT do
   Teltonika router API client.
   """
 
-  alias __MODULE__.{Auth, Scheduler, SystemInformation}
+  alias __MODULE__.{Auth, ModemStatus, Scheduler, SystemInformation}
 
   def system_information do
     do_request(nil, "/system/device/status", fn data ->
@@ -14,6 +14,12 @@ defmodule ExNVR.Nerves.RUT do
         model: data["static"]["model"],
         fw_version: data["static"]["fw_version"]
       }
+    end)
+  end
+
+  def modems_status do
+    do_request(nil, "/modems/status", fn entries ->
+      Enum.map(entries, &ModemStatus.from_response/1)
     end)
   end
 

--- a/nerves_fw/lib/nerves_fw/rut/modem_status.ex
+++ b/nerves_fw/lib/nerves_fw/rut/modem_status.ex
@@ -1,0 +1,35 @@
+defmodule ExNVR.Nerves.RUT.ModemStatus do
+  @moduledoc false
+
+  @derive Jason.Encoder
+  defstruct [
+    :id,
+    :imei,
+    :model,
+    :name,
+    :state,
+    :txbytes,
+    :rxbytes,
+    :provider,
+    :signal,
+    :temperature,
+    :connection_type
+  ]
+
+  @spec from_response(map()) :: %__MODULE__{}
+  def from_response(data) do
+    %__MODULE__{
+      id: data["id"],
+      imei: data["imei"],
+      model: data["model"],
+      name: data["name"],
+      state: data["state"],
+      txbytes: data["txbytes"],
+      rxbytes: data["rxbytes"],
+      provider: data["provider"],
+      signal: data["signal"],
+      temperature: data["temperature"],
+      connection_type: data["conntype"]
+    }
+  end
+end


### PR DESCRIPTION
Closes #961 

Get the router's modem temperature and use it as an input to calculate the final temperature fed to the fan. The calculation is a simple average: `(internal temp + modem_temp) / 2`.

Also changed the lookup table to:
```
Degrees, speed %
{30, 20}
{40, 30}
{45, 45}
{50, 65}
{60, 85}
{70, 100}
```