### PR TITLE
Suggested improvements to the health page

### DIFF
--- a/ui/assets/js/app.js
+++ b/ui/assets/js/app.js
@@ -80,6 +80,7 @@ let Hooks = {
     CameraPreview: {
         mounted() {
             this.attach()
+            this.setupFullscreen()
         },
         updated() {
             const url = this.el.dataset.streamUrl
@@ -90,6 +91,27 @@ let Hooks = {
                 this._hls.destroy()
                 this._hls = null
             }
+            if (this._fsBtn && this._fsHandler) {
+                this._fsBtn.removeEventListener("click", this._fsHandler)
+                this._fsBtn = null
+                this._fsHandler = null
+            }
+        },
+        setupFullscreen() {
+            const container = this.el.parentElement
+            if (!container) return
+            const btn = container.querySelector("[data-fullscreen-btn]")
+            if (!btn) return
+            this._fsHandler = (event) => {
+                event.preventDefault()
+                if (document.fullscreenElement) {
+                    document.exitFullscreen()
+                } else if (container.requestFullscreen) {
+                    container.requestFullscreen()
+                }
+            }
+            btn.addEventListener("click", this._fsHandler)
+            this._fsBtn = btn
         },
         attach() {
             const url = this.el.dataset.streamUrl

--- a/ui/lib/ex_nvr_web/components/health.ex
+++ b/ui/lib/ex_nvr_web/components/health.ex
@@ -512,7 +512,7 @@ defmodule ExNVRWeb.Components.Health do
       |> assign(:name, assigns.device[:name])
       |> assign(:type, assigns.device[:type])
       |> assign(:streaming?, streaming?)
-      |> assign(:stream_url, "/api/devices/#{device_id}/hls/index.m3u8?stream=high")
+      |> assign(:stream_url, "/api/devices/#{device_id}/hls/index.m3u8?stream=low")
       |> assign(:dom_id, "camera-preview-#{device_id}")
 
     ~H"""

--- a/ui/lib/ex_nvr_web/components/health.ex
+++ b/ui/lib/ex_nvr_web/components/health.ex
@@ -44,8 +44,7 @@ defmodule ExNVRWeb.Components.Health do
   def not_connected(assigns) do
     ~H"""
     <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-      <span class="h-2 w-2 rounded-full bg-gray-400 dark:bg-gray-500 shrink-0"></span>
-      Not connected
+      <span class="h-2 w-2 rounded-full bg-gray-400 dark:bg-gray-500 shrink-0"></span> Not connected
     </div>
     """
   end

--- a/ui/lib/ex_nvr_web/components/health.ex
+++ b/ui/lib/ex_nvr_web/components/health.ex
@@ -41,6 +41,15 @@ defmodule ExNVRWeb.Components.Health do
     """
   end
 
+  def not_connected(assigns) do
+    ~H"""
+    <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <span class="h-2 w-2 rounded-full bg-gray-400 dark:bg-gray-500 shrink-0"></span>
+      Not connected
+    </div>
+    """
+  end
+
   ## CPU
 
   attr :usage, :list, default: []
@@ -372,6 +381,12 @@ defmodule ExNVRWeb.Components.Health do
 
   attr :solar, :any, required: true
 
+  def solar_section(%{solar: nil} = assigns) do
+    ~H"""
+    <.not_connected />
+    """
+  end
+
   def solar_section(assigns) do
     ~H"""
     <.kv label="Vendor" value={Map.get(@solar, :pid) || "—"} />
@@ -388,6 +403,12 @@ defmodule ExNVRWeb.Components.Health do
   ## UPS
 
   attr :ups, :any, required: true
+
+  def ups_section(%{ups: nil} = assigns) do
+    ~H"""
+    <.not_connected />
+    """
+  end
 
   def ups_section(assigns) do
     ~H"""
@@ -433,6 +454,12 @@ defmodule ExNVRWeb.Components.Health do
 
   attr :fan, :any, required: true
 
+  def fan_section(%{fan: nil} = assigns) do
+    ~H"""
+    <.not_connected />
+    """
+  end
+
   def fan_section(assigns) do
     ~H"""
     <.kv label="Internal temp" value={format_temp(Map.get(@fan, :internal_temp))} />
@@ -456,7 +483,7 @@ defmodule ExNVRWeb.Components.Health do
 
   def camera_grid(assigns) do
     ~H"""
-    <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+    <div class="flex flex-wrap justify-center gap-4">
       <.camera_card
         :for={device <- @devices}
         device={device}
@@ -490,7 +517,7 @@ defmodule ExNVRWeb.Components.Health do
       |> assign(:dom_id, "camera-preview-#{device_id}")
 
     ~H"""
-    <section class="bg-white dark:bg-gray-800 shadow-sm rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+    <section class="grow basis-[30rem] max-w-4xl bg-white dark:bg-gray-800 shadow-sm rounded-lg p-4 border border-gray-200 dark:border-gray-700">
       <header class="flex items-start justify-between mb-3">
         <div>
           <h3 class="text-lg font-medium truncate">{@name}</h3>
@@ -501,7 +528,7 @@ defmodule ExNVRWeb.Components.Health do
         <.recording_badge state={@state} />
       </header>
 
-      <div class="aspect-video bg-gray-100 dark:bg-gray-900 rounded mb-3 overflow-hidden flex items-center justify-center">
+      <div class="group relative aspect-video bg-gray-100 dark:bg-gray-900 rounded mb-3 overflow-hidden flex items-center justify-center">
         <video
           :if={@streaming?}
           id={@dom_id}
@@ -513,6 +540,29 @@ defmodule ExNVRWeb.Components.Health do
           playsinline
           class="w-full h-full object-contain"
         />
+        <button
+          :if={@streaming?}
+          type="button"
+          data-fullscreen-btn
+          aria-label="Toggle fullscreen"
+          title="Fullscreen"
+          class="absolute bottom-2 right-2 z-10 p-1.5 rounded-md bg-black/50 text-white opacity-100"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M4 8V4h4M16 4h4v4M20 16v4h-4M8 20H4v-4"
+            />
+          </svg>
+        </button>
         <p :if={not @streaming?} class="text-xs text-gray-500 dark:text-gray-400">
           {preview_placeholder(@state)}
         </p>

--- a/ui/lib/ex_nvr_web/live/health_dashboard_live.html.heex
+++ b/ui/lib/ex_nvr_web/live/health_dashboard_live.html.heex
@@ -25,9 +25,9 @@
     </div>
   </div>
 
-  <.health_summary results={@health} />
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <.health_summary results={@health} />
 
-  <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 mt-4">
     <.panel title="Device">
       <.kv label="Hostname" value={@status[:hostname]} />
       <.kv label="Version" value={@status[:version]} />
@@ -35,7 +35,21 @@
       <.kv label="Serial" value={@status[:serial_number]} />
       <.kv :if={@status[:nerves]} label="Platform" value="Nerves" />
     </.panel>
+  </div>
 
+  <div class="mt-8">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-xl font-semibold">Cameras</h2>
+      <span class="text-xs text-gray-500 dark:text-gray-400">
+        {length(@status[:devices] || [])} device{if length(@status[:devices] || []) == 1,
+          do: "",
+          else: "s"}
+      </span>
+    </div>
+    <.camera_grid devices={@status[:devices] || []} history={@pipeline_history} />
+  </div>
+
+  <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 mt-4">
     <.panel title="CPU">
       <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
         Per-core usage
@@ -63,7 +77,7 @@
       </div>
     </.panel>
 
-    <.panel :if={@status[:solar_charger]} title="Solar Charger">
+    <.panel title="Solar Charger">
       <.solar_section solar={@status[:solar_charger]} />
       <div class="mt-3 space-y-1.5">
         <.sparkline
@@ -95,24 +109,12 @@
       <.network_section router={@status[:router]} netbird={@status[:netbird]} />
     </.panel>
 
-    <.panel :if={@status[:ups]} title="UPS">
+    <.panel title="UPS">
       <.ups_section ups={@status[:ups]} />
     </.panel>
 
-    <.panel :if={@status[:fan]} title="Fan">
+    <.panel title="Fan">
       <.fan_section fan={@status[:fan]} />
     </.panel>
-  </div>
-
-  <div class="mt-8">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="text-xl font-semibold">Cameras</h2>
-      <span class="text-xs text-gray-500 dark:text-gray-400">
-        {length(@status[:devices] || [])} device{if length(@status[:devices] || []) == 1,
-          do: "",
-          else: "s"}
-      </span>
-    </div>
-    <.camera_grid devices={@status[:devices] || []} history={@pipeline_history} />
   </div>
 </div>


### PR DESCRIPTION
### The PR includes
- Bumping the cameras cards to the top so during checks and installation mode, the FoV is easily accessible/seen.
- Make the UPS, Fans and Solar charger cards always visible with a `not connected` label if the data is not present.
- Bump the device info to the top to have a cleaner layout
- Using the sub stream for camera cards instead of the main one to save bandwidth

### The new proposed layout
<img width="3830" height="1867" alt="image" src="https://github.com/user-attachments/assets/36883ce4-309e-4cdb-a00b-94c4b256188b" />
<img width="3827" height="1837" alt="image" src="https://github.com/user-attachments/assets/68ef26f1-6e07-47f5-8b84-b9f2f0a39e07" />
